### PR TITLE
Fix typo in error subscription in Observable#do

### DIFF
--- a/lib/rx/linq/observable/do.rb
+++ b/lib/rx/linq/observable/do.rb
@@ -22,7 +22,7 @@ module Rx
           },
           lambda {|err|
             begin
-              on_error_func && on_error_func.call(x)
+              on_error_func && on_error_func.call(err)
             rescue => e
               observer.on_error e
             end

--- a/test/rx/linq/observable/test_do.rb
+++ b/test/rx/linq/observable/test_do.rb
@@ -1,0 +1,16 @@
+require "#{File.dirname(__FILE__)}/../../../test_helper"
+
+class TestObservableDo < Minitest::Test
+  def test_do_error_propagation
+    expected = RuntimeError.new
+    actual = nil
+    assert_raises(RuntimeError) do
+      Rx::Observable.raise_error(expected).do(
+        ->(_) {},
+        ->(_err) { actual = _err },
+        -> {}
+      ).subscribe
+    end
+    assert_equal actual, expected
+  end
+end


### PR DESCRIPTION
Mirrored from ReactiveX/RxRuby#110. Many thanks to @bjorne.