### PR TITLE
Revert "Add synchronize to subject (minamimonji/fix_conccurency_issue)"

### DIFF
--- a/lib/rx/subjects/subject.rb
+++ b/lib/rx/subjects/subject.rb
@@ -40,7 +40,7 @@ module Rx
         end 
       end
 
-      os.each {|o| @gate.synchronize { o.on_completed } } if os
+      os.each {|o| o.on_completed } if os
     end
 
     # Notifies all subscribed observers with the error.
@@ -59,7 +59,7 @@ module Rx
         end         
       end
 
-      os.each {|o| @gate.synchronize { o.on_error error } } if os
+      os.each {|o| o.on_error error } if os
     end
 
     # Notifies all subscribed observers with the value.
@@ -70,7 +70,7 @@ module Rx
         os = @observers.clone unless @stopped
       end
 
-      os.each {|o| @gate.synchronize { o.on_next value } } if os      
+      os.each {|o| o.on_next value } if os      
     end
 
     # Subscribes an observer to the subject.

--- a/test/rx/subjects/test_subject.rb
+++ b/test/rx/subjects/test_subject.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class TestBehaviorSubject < Minitest::Test
+  def test_unsubscribe_through_autodetach_observer
+    subject = Rx::Subject.new
+    subject.map {|_| }.subscribe { }
+    subject.on_completed
+  end
+end


### PR DESCRIPTION
As it turns out, digging out random (possibly unfinished) branches from other forks was a bit hasty 😞 . This reverts one of those as it failed thus:
```
ThreadError: deadlock; recursive locking
    /Users/quest/projects/personal/rxruby/lib/rx/subjects/subject.rb:122:in `synchronize'
    /Users/quest/projects/personal/rxruby/lib/rx/subjects/subject.rb:122:in `unsubscribe_observer'
    /Users/quest/projects/personal/rxruby/lib/rx/subjects/subject.rb:112:in `unsubscribe'
    /Users/quest/projects/personal/rxruby/lib/rx/subscriptions/single_assignment_subscription.rb:60:in `unsubscribe'
    /Users/quest/projects/personal/rxruby/lib/rx/core/auto_detach_observer.rb:54:in `unsubscribe'
    /Users/quest/projects/personal/rxruby/lib/rx/core/auto_detach_observer.rb:32:in `on_completed_core'
```