### PR TITLE
Remove #clock attribute from testing schedulers

### DIFF
--- a/lib/rx/concurrency/virtual_time_scheduler.rb
+++ b/lib/rx/concurrency/virtual_time_scheduler.rb
@@ -11,8 +11,6 @@ module Rx
 
     include Scheduler
 
-    attr_reader :clock
-
     def initialize(initial_clock)
       @clock = initial_clock.to_i
       @queue = PriorityQueue.new
@@ -21,7 +19,7 @@ module Rx
 
     # Gets the scheduler's notion of current time.
     def now
-      clock
+      @clock
     end
 
     # Gets whether the scheduler is enabled to run work.
@@ -56,7 +54,7 @@ module Rx
     # Schedules an action to be executed.
     def schedule_with_state(state, action)
       raise 'action cannot be nil' unless action
-      schedule_at_absolute_with_state(state, clock, action)
+      schedule_at_absolute_with_state(state, @clock, action)
     end
 
     # Schedules an action to be executed at due_time.
@@ -100,8 +98,8 @@ module Rx
 
     # Advances the scheduler's clock to the specified time, running all work till that point.
     def advance_to(time)
-      due_to_clock = time<=>clock
-      raise 'Time is out of range' if due_to_clock < 0 
+      due_to_clock = time<=>@clock
+      raise 'Time is out of range' if due_to_clock < 0
 
       return if due_to_clock == 0
 
@@ -130,7 +128,7 @@ module Rx
     def advance_by(time)
       dt = @clock + time
 
-      due_to_clock = dt<=>clock
+      due_to_clock = dt<=>@clock
       raise 'Time is out of range' if due_to_clock < 0
 
       return if due_to_clock == 0

--- a/lib/rx/testing/cold_observable.rb
+++ b/lib/rx/testing/cold_observable.rb
@@ -22,7 +22,7 @@ module Rx
     def subscribe(observer)
       raise 'observer cannot be nil' unless observer
 
-      subscriptions.push(TestSubscription.new @scheduler.clock)
+      subscriptions.push(TestSubscription.new @scheduler.now)
       index = subscriptions.length - 1
 
       d = CompositeSubscription.new
@@ -37,7 +37,7 @@ module Rx
       end
 
       return Subscription.create do
-        subscriptions[index] = TestSubscription.new(subscriptions[index].subscribe, @scheduler.clock)
+        subscriptions[index] = TestSubscription.new(subscriptions[index].subscribe, @scheduler.now)
         d.unsubscribe
       end
     end

--- a/lib/rx/testing/hot_observable.rb
+++ b/lib/rx/testing/hot_observable.rb
@@ -34,13 +34,13 @@ module Rx
       raise 'observer cannot be nil' unless observer
 
       @observers.push observer
-      subscriptions.push (TestSubscription.new @scheduler.clock)
+      subscriptions.push (TestSubscription.new @scheduler.now)
 
       index = subscriptions.length - 1
 
-      Subscription.create do 
+      Subscription.create do
         @observers.delete observer
-        subscriptions[index] = TestSubscription.new(subscriptions[index].subscribe, @scheduler.clock)
+        subscriptions[index] = TestSubscription.new(subscriptions[index].subscribe, @scheduler.now)
       end
     end
   end

--- a/lib/rx/testing/mock_observer.rb
+++ b/lib/rx/testing/mock_observer.rb
@@ -17,15 +17,15 @@ module Rx
     end
 
     def on_next(value)
-      messages.push(Recorded.new(@scheduler.clock, Notification.create_on_next(value)))
+      messages.push(Recorded.new(@scheduler.now, Notification.create_on_next(value)))
     end
 
     def on_error(error)
-      messages.push(Recorded.new(@scheduler.clock, Notification.create_on_error(error)))
+      messages.push(Recorded.new(@scheduler.now, Notification.create_on_error(error)))
     end
 
     def on_completed
-      messages.push(Recorded.new(@scheduler.clock, Notification.create_on_completed))
+      messages.push(Recorded.new(@scheduler.now, Notification.create_on_completed))
     end
   end
 end

--- a/lib/rx/testing/test_scheduler.rb
+++ b/lib/rx/testing/test_scheduler.rb
@@ -19,8 +19,8 @@ module Rx
     # Schedules an action to be executed at due_time.
     def schedule_at_absolute_with_state(state, due_time, action)
       raise 'action cannot be nil' unless action
-      
-      due_time = clock + 1 if due_time <= clock
+
+      due_time = now + 1 if due_time <= now
 
       super(state, due_time, action)
     end

--- a/test/rx/concurrency/helpers/historical_virtual_scheduler_helper.rb
+++ b/test/rx/concurrency/helpers/historical_virtual_scheduler_helper.rb
@@ -30,10 +30,6 @@ module HistoricalVirtualSchedulerTestHelper
     assert_equal(@start, @scheduler.now)
   end
 
-  def test_clock
-    assert_equal @start, @scheduler.clock
-  end
-
   # Relative Scheduling
 
   def test_relative_with_state

--- a/test/rx/core/test_observable_creation.rb
+++ b/test/rx/core/test_observable_creation.rb
@@ -164,7 +164,7 @@ class TestObservableCreation < Minitest::Test
         invoked += 1
 
         xs = scheduler.create_cold_observable(
-          on_next(100, scheduler.clock),
+          on_next(100, scheduler.now),
           on_completed(200)
         )
         xs
@@ -172,26 +172,26 @@ class TestObservableCreation < Minitest::Test
     end
 
     msgs = [on_next(300, 200), on_completed(400)]
-    assert_messages msgs, res.messages    
+    assert_messages msgs, res.messages
 
     assert_equal 1, invoked
 
-    assert_subscriptions [subscribe(200, 400)], xs.subscriptions 
+    assert_subscriptions [subscribe(200, 400)], xs.subscriptions
   end
 
   def test_defer_error
-    scheduler = Rx::TestScheduler.new 
+    scheduler = Rx::TestScheduler.new
 
     invoked = 0
     xs = nil
     err = RuntimeError.new
 
-    res = scheduler.configure do 
+    res = scheduler.configure do
       Rx::Observable.defer do
         invoked += 1
 
         xs = scheduler.create_cold_observable(
-          on_next(100, scheduler.clock),
+          on_next(100, scheduler.now),
           on_error(200, err)
         )
         xs
@@ -207,17 +207,17 @@ class TestObservableCreation < Minitest::Test
   end
 
   def test_defer_unsubscribe
-    scheduler = Rx::TestScheduler.new 
+    scheduler = Rx::TestScheduler.new
 
     invoked = 0
     xs = nil
 
-    res = scheduler.configure do 
+    res = scheduler.configure do
       Rx::Observable.defer do
         invoked += 1
 
         xs = scheduler.create_cold_observable(
-          on_next(100, scheduler.clock),
+          on_next(100, scheduler.now),
           on_next(200, invoked),
           on_next(1100, 1000)
         )

--- a/test/rx/linq/observable/test_if.rb
+++ b/test/rx/linq/observable/test_if.rb
@@ -11,7 +11,7 @@ class TestObservableCreation < Minitest::Test
       xs = Rx::Observable.if(
         lambda { called = true; true },
         scheduler.create_cold_observable(
-          on_next(100, scheduler.clock),
+          on_next(100, scheduler.now),
           on_completed(200)
         )
       )


### PR DESCRIPTION
Testing schedulers were maintaining and using a separate #clock attribute that was effectively identical to real schedulers' #now which `VirutalTimeScheduler` was anyway overriding. This made it difficult to use test fixtures with real schedulers so this PR removes this special case and updates testing fixtures to use `#now`.