### PR TITLE
.do operator accepts nil for on_next

### DIFF
--- a/lib/rx/linq/observable/do.rb
+++ b/lib/rx/linq/observable/do.rb
@@ -15,31 +15,36 @@ module Rx
         on_completed_func = observer_or_on_next.method(:on_completed)
       end
       AnonymousObservable.new do |observer|
-        subscribe(
-          lambda {|x|
+        new_obs = Rx::Observer.configure do |o|
+          o.on_next do |x|
             begin
               on_next_func && on_next_func.call(x)
             rescue => e
               observer.on_error e
             end
             observer.on_next x
-          },
-          lambda {|err|
+          end
+
+          o.on_error do |err|
             begin
               on_error_func && on_error_func.call(err)
             rescue => e
               observer.on_error e
             end
             observer.on_error err
-          },
-          lambda {
+          end
+
+          o.on_completed do
             begin
               on_completed_func && on_completed_func.call
             rescue => e
               observer.on_error e
             end
             observer.on_completed
-          })
+          end
+        end
+
+        subscribe new_obs
       end
     end
   end

--- a/lib/rx/linq/observable/do.rb
+++ b/lib/rx/linq/observable/do.rb
@@ -1,4 +1,6 @@
 module Rx
+  # Invokes the observer's methods for each message in the source sequence.
+  # This method can be used for debugging, logging, etc. of query behavior by intercepting the message stream to run arbitrary actions for messages on the pipeline.
   module Observable
     # Invokes the observer's methods for each message in the source sequence.
     # This method can be used for debugging, logging, etc. of query behavior by intercepting the message stream to run arbitrary actions for messages on the pipeline.

--- a/lib/rx/linq/observable/do.rb
+++ b/lib/rx/linq/observable/do.rb
@@ -7,6 +7,8 @@ module Rx
         on_next_func = Proc.new
       elsif Proc === observer_or_on_next
         on_next_func = observer_or_on_next
+      elsif observer_or_on_next.nil?
+        on_next_func = nil
       else
         on_next_func = observer_or_on_next.method(:on_next)
         on_error_func = observer_or_on_next.method(:on_error)
@@ -16,7 +18,7 @@ module Rx
         subscribe(
           lambda {|x|
             begin
-              on_next_func.call x
+              on_next_func && on_next_func.call(x)
             rescue => e
               observer.on_error e
             end

--- a/lib/rx/linq/observable/do.rb
+++ b/lib/rx/linq/observable/do.rb
@@ -1,5 +1,7 @@
 module Rx
   module Observable
+    # Invokes the observer's methods for each message in the source sequence.
+    # This method can be used for debugging, logging, etc. of query behavior by intercepting the message stream to run arbitrary actions for messages on the pipeline.
     def do(observer_or_on_next = nil, on_error_func = nil, on_completed_func = nil)
       if block_given?
         on_next_func = Proc.new

--- a/lib/rx/operators/single.rb
+++ b/lib/rx/operators/single.rb
@@ -66,49 +66,6 @@ module Rx
       end
     end
 
-    # Invokes the observer's methods for each message in the source sequence.
-    # This method can be used for debugging, logging, etc. of query behavior by intercepting the message stream to run arbitrary actions for messages on the pipeline.
-    def tap(observer)
-      raise ArgumentError.new 'Observer cannot be nil' unless observer
-      AnonymousObservable.new do |obs|
-        new_obs = Rx::Observer.configure do |o|
-
-          o.on_next do |value|
-            begin
-              observer.on_next value
-            rescue => err
-              obs.on_error err
-            end
-
-            obs.on_next value
-          end
-
-          o.on_error do |err|
-            begin
-              observer.on_error err
-            rescue => e
-              obs.on_error e
-            end
-
-            obs.on_error err
-          end
-
-          o.on_completed do
-            begin
-              observer.on_completed
-            rescue => err
-              obs.on_error err
-            end
-
-            obs.on_completed
-          end
-
-        end
-
-        subscribe new_obs
-      end
-    end
-
     # Invokes a specified action after the source observable sequence terminates gracefully or exceptionally.
     def ensures
       AnonymousObservable.new do |observer|

--- a/test/rx/linq/observable/test_do.rb
+++ b/test/rx/linq/observable/test_do.rb
@@ -77,6 +77,34 @@ class TestOperatorDo < Minitest::Test
     assert_messages [on_error(SUBSCRIBED + 100, @err)], res.messages
   end
 
+  def test_do_with_observer
+    mock = Rx::MockObserver.new(@scheduler)
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_next(100, 1),
+        on_completed(200)
+      ).do(mock)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_completed(SUBSCRIBED + 200)
+    ]
+    assert_messages expected, mock.messages
+    assert_messages res.messages, mock.messages
+  end
+
+  def test_do_on_error_with_observer
+    mock = Rx::MockObserver.new(@scheduler)
+    @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_error(100, @err)
+      ).do(mock)
+    end
+
+    assert_messages [on_error(SUBSCRIBED + 100, @err)], mock.messages
+  end
+
   def test_do_error_propagation
     expected = RuntimeError.new
     actual = nil

--- a/test/rx/linq/observable/test_do.rb
+++ b/test/rx/linq/observable/test_do.rb
@@ -55,7 +55,7 @@ class TestOperatorDo < Minitest::Test
         on_error(100, 1)
       ).do(nil, lambda { |e| raise @err })
     end
-    assert_messages [on_error(S7BSCRIBED + 100, @err)], res.messages
+    assert_messages [on_error(SUBSCRIBED + 100, @err)], res.messages
   end
 
   def test_do_with_on_completed
@@ -63,7 +63,7 @@ class TestOperatorDo < Minitest::Test
     @scheduler.configure do
       @scheduler.create_cold_observable(
         on_completed(100)
-      ).do(nil, nil, lambda { :done })
+      ).do(nil, nil, lambda { messages << :done })
     end
     assert_equal [:done], messages
   end

--- a/test/rx/linq/observable/test_do.rb
+++ b/test/rx/linq/observable/test_do.rb
@@ -1,6 +1,82 @@
-require "#{File.dirname(__FILE__)}/../../../test_helper"
+require 'test_helper'
 
-class TestObservableDo < Minitest::Test
+class TestOperatorDo < Minitest::Test
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+    @err = RuntimeError.new
+  end
+
+  def test_do_with_proc
+    messages = []
+    @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_next(100, 1),
+        on_completed(200)
+      ).do { |e| messages << e }
+    end
+    assert_equal [1], messages
+  end
+
+  def test_do_with_on_next
+    messages = []
+    @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_next(100, 1),
+        on_completed(200)
+      ).do(lambda { |e| messages << e })
+    end
+    assert_equal [1], messages
+  end
+
+  def test_do_with_erroring_on_next
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_next(100, 1)
+      ).do(lambda { |e| raise @err })
+    end
+    assert_messages [on_error(SUBSCRIBED + 100, @err)], res.messages
+  end
+
+  def test_do_with_on_error
+    messages = []
+    @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_error(100, @err)
+      ).do(nil, lambda { |e| messages << e })
+    end
+    assert_equal [@err], messages
+  end
+
+  def test_do_with_erroring_on_error
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_error(100, 1)
+      ).do(nil, lambda { |e| raise @err })
+    end
+    assert_messages [on_error(S7BSCRIBED + 100, @err)], res.messages
+  end
+
+  def test_do_with_on_completed
+    messages = []
+    @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_completed(100)
+      ).do(nil, nil, lambda { :done })
+    end
+    assert_equal [:done], messages
+  end
+
+  def test_do_with_erroring_on_completed
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_completed(100)
+      ).do(nil, nil, lambda { raise @err })
+    end
+    assert_messages [on_error(SUBSCRIBED + 100, @err)], res.messages
+  end
+
   def test_do_error_propagation
     expected = RuntimeError.new
     actual = nil


### PR DESCRIPTION
Despite defaulting its first argument to `nil`, `.do` unhelpfully threw nil-class errors on e.g. `.do(nil, lambda {|e| ... }, lambda { ... })`. This PR updates the operator to accepts `nil` for each of its argument.

Since this was the first change to `.do`, I added tests for all aspects of the operator behavior.

Update `.do` to use `Observer.configure` explicitly (like most other operators), rather than depend on `Observable.subscribe` to do it for us. Mysteriously, this was needed to make tests pass. This will have to be addressed by a separate PR.

This PR also removes the `.tap` which is a strict subset of `.do`. `.tap` is also a Ruby builtin present on all objects.

Fixes #5 .