### PR TITLE
Enums are not thread-safe

### DIFF
--- a/lib/rx/concurrency/threaded_enumerator.rb
+++ b/lib/rx/concurrency/threaded_enumerator.rb
@@ -10,6 +10,12 @@ module Rx
     ERROR = Object.new
     DONE = Object.new
 
+    if RUBY_ENGINE == 'jruby'
+      def self.new(*args, &block)
+        Enumerator.new(*args, &block)
+      end
+    end
+
     # ThreadedEnumerator helper class
     class Yielder
       def initialize(queue, gate, condition)
@@ -30,13 +36,13 @@ module Rx
     # receives a yielder object, but not both. Note that the block or enumerable
     # will be iterated immediately once making it possible to prepare the iterator
     # e.g. when reading from a file or a socket.
-    def initialize(source = nil, &block)
-      raise ArgumentError, 'Will not accept both source and block' if source && block_given?
+    def initialize(source_or_size_hint = nil, &block)
+      raise TypeError, 'Size hinting not supported' if source_or_size_hint && block_given?
       @condition = ConditionVariable.new
       @gate = Mutex.new
       @queue = Queue.new
       @done = false
-      setup_yielder(source, &block)
+      setup_yielder(source_or_size_hint, &block)
     end
 
     # Receive the next item from the enumerator or any exception thrown from the

--- a/lib/rx/concurrency/threaded_enumerator.rb
+++ b/lib/rx/concurrency/threaded_enumerator.rb
@@ -1,0 +1,79 @@
+module Rx
+  # ThreadedEnumerator can be used across threads unlike Ruby's default Enumerator
+  # that will throw FiberError if the enumerator is used from more than one
+  # thread. You should use this class instead of vanilla Enumerator with oeprators
+  # such as Rx::Observable.concat or Rx::Observable#rescue_error if they observe
+  # on multiple async sources. Note that this does not mean that ThreadedEnumerator
+  # is thread-safe in the stricter sense of the word: avoid calling #next from
+  # multiple threads concurrently.
+  class ThreadedEnumerator
+    ERROR = Object.new
+    DONE = Object.new
+
+    # ThreadedEnumerator helper class
+    class Yielder
+      def initialize(queue, gate, condition)
+        @queue = queue
+        @gate = gate
+        @condition = condition
+      end
+
+      def <<(e)
+        @queue << e
+        @gate.synchronize do
+          @condition.wait @gate while @queue.size > 0
+        end
+      end
+    end
+
+    # The enumerator can be created with either an enumerable or a block that
+    # receives a yielder object, but not both. Note that the block or enumerable
+    # will be iterated immediately once making it possible to prepare the iterator
+    # e.g. when reading from a file or a socket.
+    def initialize(source = nil, &block)
+      raise ArgumentError, 'Will not accept both source and block' if source && block_given?
+      @condition = ConditionVariable.new
+      @gate = Mutex.new
+      @queue = Queue.new
+      @done = false
+      setup_yielder(source, &block)
+    end
+
+    # Receive the next item from the enumerator or any exception thrown from the
+    # enumerator.
+    def next
+      raise StopIteration if @done
+      @gate.synchronize do
+        @condition.signal
+      end
+      payload, type = @queue.pop
+      case type
+      when DONE
+        @done = true
+        raise StopIteration
+      when ERROR
+        @done = true
+        raise payload
+      end
+      payload
+    end
+
+    private
+
+    def setup_yielder(source, &block)
+      yielder = Yielder.new(@queue, @gate, @condition)
+      Thread.new do
+        begin
+          if source
+            source.each { |e| yielder << e }
+          else
+            block.call yielder
+          end
+        rescue => e
+          yielder << [e, ERROR]
+        end
+        yielder << [nil, DONE]
+      end
+    end
+  end
+end

--- a/lib/rx/linq/observable/for.rb
+++ b/lib/rx/linq/observable/for.rb
@@ -2,7 +2,7 @@ module Rx
   class << Observable
     def for(sources, result_selector = nil)
       result_selector ||= lambda {|*args| args}
-      enum = Enumerator.new {|y|
+      enum = ThreadedEnumerator.new {|y|
         sources.each {|v|
           y << result_selector.call(v)
         }

--- a/lib/rx/linq/observable/while.rb
+++ b/lib/rx/linq/observable/while.rb
@@ -1,7 +1,7 @@
 module Rx
   class << Observable
     def while(condition, source)
-      enum = Enumerator.new {|y|
+      enum = ThreadedEnumerator.new {|y|
         while condition.call
           y << source
         end

--- a/lib/rx/operators/multiple.rb
+++ b/lib/rx/operators/multiple.rb
@@ -193,7 +193,7 @@ module Rx
 
     # Concatenates the second observable sequence to the first observable sequence upon successful termination of the first.
     def concat(*other)
-      Observable.concat([self, *other].to_enum)
+      Observable.concat(self, *other)
     end
 
     # Merges elements from two observable sequences into a single observable sequence, using the specified scheduler for enumeration of and subscription to the sources.
@@ -432,7 +432,7 @@ module Rx
         AnonymousObservable.new do |observer|
           gate = AsyncLock.new
           disposed = false
-          e = args.length == 1 && args[0].is_a?(Enumerator) ? args[0] : args.to_enum
+          e = args.length == 1 && args[0].respond_to?(:next) ? args[0] : ThreadedEnumerator.new(args)
           subscription = SerialSubscription.new
           last_error = nil
 
@@ -553,7 +553,7 @@ module Rx
       def concat(*args)
         AnonymousObservable.new do |observer|
           disposed = false
-          e = args.length == 1 && args[0].is_a?(Enumerator) ? args[0] : args.to_enum
+          e = args.length == 1 && args[0].respond_to?(:next) ? args[0] : ThreadedEnumerator.new(args)
           subscription = SerialSubscription.new
           gate = AsyncLock.new
 
@@ -623,7 +623,7 @@ module Rx
         AnonymousObservable.new do |observer|
           gate = AsyncLock.new
           disposed = false
-          e = args.length == 1 && args[0].is_a?(Enumerator) ? args[0] : args.to_enum
+          e = args.length == 1 && args[0].respond_to?(:next) ? args[0] : ThreadedEnumerator.new(args)
           subscription = SerialSubscription.new
 
           cancelable = CurrentThreadScheduler.instance.schedule_recursive lambda {|this|

--- a/lib/rx/operators/single.rb
+++ b/lib/rx/operators/single.rb
@@ -380,7 +380,7 @@ module Rx
     end
 
     def enumerator_repeat_times(num, value)
-      Enumerator.new do |y|
+      ThreadedEnumerator.new do |y|
         num.times do |i|
           y << value
         end
@@ -388,7 +388,7 @@ module Rx
     end
 
     def enumerator_repeat_infinitely(value)
-      Enumerator.new do |y|
+      ThreadedEnumerator.new do |y|
         while true
           y << value
         end

--- a/test/rx/concurrency/test_threaded_enumerator.rb
+++ b/test/rx/concurrency/test_threaded_enumerator.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+module Rx
+  class TestThreadedEnumerator < Minitest::Test
+    def setup
+      @enum = ThreadedEnumerator.new do |y|
+        y << 1
+        y << 2
+        y << 3
+      end
+    end
+
+    def test_returns_next_element
+      assert_equal 1, @enum.next
+      assert_equal 2, @enum.next
+      assert_equal 3, @enum.next
+    end
+
+    def test_raises_stop_iteration
+      3.times { @enum.next }
+      assert_raises(StopIteration) { @enum.next }
+      assert_raises(StopIteration) { @enum.next }
+    end
+
+    def test_propagates_errors_from_yielder_thread
+      enum = ThreadedEnumerator.new do |y|
+        raise RuntimeError.new
+      end
+      assert_raises(RuntimeError) { enum.next }
+    end
+
+    def test_called_across_threads
+      result = []
+      3.times { Thread.new { result << @enum.next }.join }
+      assert_equal [1, 2, 3], result
+    end
+
+    def test_slow_yield
+      enum = ThreadedEnumerator.new do |y|
+        (1..3).each { |n| sleep 0.01 ; y << n }
+      end
+      3.times { enum.next }
+      assert_raises(StopIteration) { enum.next }
+    end
+
+    def test_slow_poll
+      3.times { sleep 0.01 ; @enum.next }
+      assert_raises(StopIteration) { @enum.next }
+      assert_raises(StopIteration) { @enum.next }
+    end
+
+    def test_construct_from_enumerable
+      enum = ThreadedEnumerator.new([1, 2, 3])
+      assert_equal [1, 2, 3], 3.times.map { enum.next }
+      assert_raises(StopIteration) { enum.next }
+    end
+
+    def test_argument_error_on_both_block_and_source
+      assert_raises(ArgumentError) { ThreadedEnumerator.new([]) { } }
+    end
+  end
+
+  class TestThreadedEnumeratorConcurrency < Minitest::Test
+    def setup
+      @enum = ThreadedEnumerator.new do |y|
+        i = 0
+        y << i += 1 until false
+      end
+    end
+
+    def test_concurrency
+      1000.times { @enum.next }
+    end
+  end
+end

--- a/test/rx/concurrency/test_threaded_enumerator.rb
+++ b/test/rx/concurrency/test_threaded_enumerator.rb
@@ -56,7 +56,7 @@ module Rx
     end
 
     def test_argument_error_on_both_block_and_source
-      assert_raises(ArgumentError) { ThreadedEnumerator.new([]) { } }
+      assert_raises(TypeError) { ThreadedEnumerator.new([]) { } }
     end
   end
 


### PR DESCRIPTION
RxRuby was using Ruby Enumerator for as an internal short-hand for repeating en Observable a fixed or infinite number of times, for example the `#repeat_infinitely` operator. The problem with this is that Enumerator is explicitly thread-averse, as is described in #4 and #10. This affects all places where one part of RxRuby is passing an Enumerator to another part, since the caller cannot know if the receiving observable will be executed across more than one thread.

This PR replaces all those occurrences with an implementation that is reasonably thread-safe. This should be enough given that a single execution of `#next` and the yielder should be protected by the "no observable reentrancy" guarantee from the ReactiveX contract.
