### PR TITLE
Remove default scheduler unsubscribe that kills threads prematurely

### DIFF
--- a/lib/rx/concurrency/default_scheduler.rb
+++ b/lib/rx/concurrency/default_scheduler.rb
@@ -22,11 +22,11 @@ module Rx
 
       d = SingleAssignmentSubscription.new
 
-      t = Thread.new do
+      Thread.new do
         d.subscription = action.call self, state unless d.unsubscribed?
       end
 
-      CompositeSubscription.new [d, Subscription.create { t.exit }]
+      d
     end
 
     # Schedules an action to be executed after dueTime
@@ -38,14 +38,14 @@ module Rx
 
       d = SingleAssignmentSubscription.new
 
-      t = Thread.new do
+      Thread.new do
         sleep dt
         Thread.new {
           d.subscription = action.call self, state unless d.unsubscribed?
         }
       end
 
-      CompositeSubscription.new [d, Subscription.create { t.exit }]         
+      d
     end
   end
 end

--- a/test/rx/operators/test_synchronization.rb
+++ b/test/rx/operators/test_synchronization.rb
@@ -3,16 +3,20 @@
 require "#{File.dirname(__FILE__)}/../../test_helper"
 
 class TestObservableSynchronization < Minitest::Test
+  include Rx::AsyncTesting
   include Rx::ReactiveTest
 
+  def setup
+    @scheduler = Rx::TestScheduler.new
+  end
+
   def test_subscribe_on
-    scheduler = Rx::TestScheduler.new
-    mock = Rx::MockObserver.new scheduler
+    mock = Rx::MockObserver.new @scheduler
     Rx::Observable.just(1)
-      .subscribe_on(scheduler)
+      .subscribe_on(@scheduler)
       .subscribe(mock)
     assert_equal 0, mock.messages.length
-    scheduler.advance_by 100
+    @scheduler.advance_by 100
     assert_equal 2, mock.messages.length
   end
 
@@ -22,5 +26,24 @@ class TestObservableSynchronization < Minitest::Test
 
   def test_subscribe_on_current_thread_scheduiler_does_not_raise
     Rx::Observable.just(1).subscribe_on(Rx::CurrentThreadScheduler.instance).subscribe
+  end
+
+  def test_subscribe_on_default_scheduler_with_merging
+    observer = @scheduler.create_observer
+    Rx::Observable.of(Rx::Observable.from([1, 2]), Rx::Observable.from([3, 4]))
+      .subscribe_on(Rx::DefaultScheduler.instance)
+      .merge_all
+      .subscribe(observer)
+
+    await_array_length(observer.messages, 5)
+
+    expected = [
+      on_next(0, 1),
+      on_next(0, 2),
+      on_next(0, 3),
+      on_next(0, 4),
+      on_completed(0)
+    ]
+    assert_messages expected, observer.messages
   end
 end


### PR DESCRIPTION
`DefaultScheduler` scheduling methods returned `CompositeSubscription`s appended with a `Thread#exit` operation. However, where the scheduling call (e.g. `subscribe_on`) occurs in the middle of a chain, we do not actually know that the thread is done when the scheduling subscription `unsubscribe` method is triggered. This resulted in operations like `merge_all` and `merge_concurrent` that lack rigid connection between upstream and downstream subscriptions  would work fine in synchronous operation, but would that the stream would mysteriously die when put on `DefaultScheduler`.

Given that `Thread#exit` on a worker thread with a finite lifecycle is a dubious concept at the best of times, this PR simply removes the composite subscription and passes out a `SingleAssignmentSubscription` instead.