### PR TITLE
Set up Codecov to allow browsing our test coverage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.org/bittrance/rxruby.svg?branch=master)](https://travis-ci.org/bittrance/rxruby)
 [![Gem Version](https://badge.fury.io/rb/rx.svg)](https://badge.fury.io/rb/rx)
 [![Downloads](http://ruby-gem-downloads-badge.herokuapp.com/rx?type=total)](https://rubygems.org/gems/rx)
+[![Coverage Status](https://coveralls.io/repos/github/bittrance/rxruby/badge.svg?branch=coveralls)](https://coveralls.io/github/bittrance/rxruby?branch=coveralls)
 [![Code Climate](https://codeclimate.com/github/bittrance/rxruby/badges/gpa.svg)](https://codeclimate.com/github/bittrance/rxruby)
 
 **[The Need to go Reactive](#the-need-to-go-reactive)** |

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/bittrance/rxruby.svg?branch=master)](https://travis-ci.org/bittrance/rxruby)
 [![Gem Version](https://badge.fury.io/rb/rx.svg)](https://badge.fury.io/rb/rx)
 [![Downloads](http://ruby-gem-downloads-badge.herokuapp.com/rx?type=total)](https://rubygems.org/gems/rx)
-[![Coverage Status](https://coveralls.io/repos/github/bittrance/rxruby/badge.svg?branch=coveralls)](https://coveralls.io/github/bittrance/rxruby?branch=coveralls)
+[![Coverage](https://codecov.io/gh/bittrance/rxruby/branch/coveralls/graph/badge.svg)](https://codecov.io/gh/bittrance/rxruby)
 [![Code Climate](https://codeclimate.com/github/bittrance/rxruby/badges/gpa.svg)](https://codeclimate.com/github/bittrance/rxruby)
 
 **[The Need to go Reactive](#the-need-to-go-reactive)** |

--- a/rx.gemspec
+++ b/rx.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Rx::VERSION
   gem.license       = 'Apache License, v2.0'
 
-  gem.add_development_dependency 'coveralls'
+  gem.add_development_dependency 'codecov'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'simplecov'

--- a/rx.gemspec
+++ b/rx.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = Rx::VERSION
   gem.license       = 'Apache License, v2.0'
 
+  gem.add_development_dependency 'coveralls'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'simplecov'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,11 +1,11 @@
-if ENV['COVERAGE']
-  require 'coveralls'
+if ENV['CODECOV_TOKEN']
   require 'simplecov'
+  require 'codecov'
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-  ]
+    SimpleCov::Formatter::Codecov
+  ])
   SimpleCov.start do
     coverage_dir '.coverage'
     add_filter do |f|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,11 @@
 if ENV['COVERAGE']
+  require 'coveralls'
   require 'simplecov'
 
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
   SimpleCov.start do
     coverage_dir '.coverage'
     add_filter do |f|


### PR DESCRIPTION
Useful when exploring the project on mobile devices or for linking to coverage-highlighted code. Plus we get a badge. Badges are good. More badges are better.