### PR TITLE
Helpers to allow writing marble-style unit tests, a la RxJS

### DIFF
--- a/lib/rx/testing/marble_testing.rb
+++ b/lib/rx/testing/marble_testing.rb
@@ -1,0 +1,67 @@
+require 'rx/testing/reactive_test'
+
+module Rx
+  module MarbleTesting
+    include Rx::ReactiveTest
+
+    def error
+      @err ||= RuntimeError.new
+    end
+
+    def msgs(events, values = {})
+      time = 0
+      events.chars.map do |event|
+        message = case event
+        when ' '
+          next
+        when '-'
+          nil
+        when '|'
+          on_completed(time)
+        when '#'
+          on_error(time, values[:error] || error)
+        else
+          on_next(time, values[event.to_sym] || event)
+        end
+        time += 100
+        message
+      end.compact
+    end
+
+    def subs(events)
+      time = 0
+      subscribe_time = nil
+      result = events.chars.map do |event|
+        sub = case event
+        when ' ', '-'
+          nil
+        when '^'
+          subscribe_time = time
+          nil
+        when '!'
+          st, subscribe_time = subscribe_time, nil
+          subscribe(st, time)
+        end
+        time += 100
+        sub
+      end.compact
+      if subscribe_time
+        result << subscribe(subscribe_time, nil)
+      end
+      result
+    end
+
+    def assert_subs(expected, actual)
+      assert_subscriptions expected, actual.subscriptions
+    end
+
+    def assert_msgs(expected, actual)
+      assert_messages expected, actual.messages
+    end
+
+    def cold(events, values = {})
+      messages = msgs(events, values)
+      scheduler.create_cold_observable(*messages)
+    end
+  end
+end

--- a/lib/rx/testing/reactive_test.rb
+++ b/lib/rx/testing/reactive_test.rb
@@ -49,6 +49,10 @@ module Rx
       TestSubscription.new(subscribe, unsubscribe)
     end
 
+    def scheduler
+      @scheduler ||= Rx::TestScheduler.new(false)
+    end
+
     def assert_messages(expected, actual)
       assert_equal expected, actual, "Message records differ (#{expected.length}/#{actual.length})"
     end

--- a/lib/rx/testing/test_scheduler.rb
+++ b/lib/rx/testing/test_scheduler.rb
@@ -12,7 +12,8 @@ module Rx
   # Virtual time scheduler used for testing applications and libraries built using Reactive Extensions.
   class TestScheduler < VirtualTimeScheduler
 
-    def initialize
+    def initialize(increment_on_simultaneous = true)
+      @increment_on_simultaneous = increment_on_simultaneous
       super(0)
     end
 
@@ -20,7 +21,7 @@ module Rx
     def schedule_at_absolute_with_state(state, due_time, action)
       raise 'action cannot be nil' unless action
 
-      due_time = now + 1 if due_time <= now
+      due_time = now + 1 if due_time <= now && @increment_on_simultaneous
 
       super(state, due_time, action)
     end


### PR DESCRIPTION
RxJS practices a testing style that builds on a mini-DSL that takes ascii-art versions of the classic marble diagrams. This makes for very compact tests and is rather expressive to anyone used to "the marbles". 
```javascript
  it('should merge cold and cold', () => {
    const e1 =  cold('---a-----b-----c----|');
    const e1subs =   '^                   !';
    const e2 =  cold('------x-----y-----z----|');
    const e2subs =   '^                      !';
    const expected = '---a--x--b--y--c--z----|';

    const result = e1.merge(e2, rxTestScheduler);

    expectObservable(result).toBe(expected);
    expectSubscriptions(e1.subscriptions).toBe(e1subs);
    expectSubscriptions(e2.subscriptions).toBe(e2subs);
});
```
This PR introduces helpers to allow writing such tests for RxRuby.

```ruby
  def test_merge_two_sequences_in_order_of_arrival
    left       = cold('  ---c|')
    right      = cold('  -ab--d|')
    expected   = msgs('---abc-d|')
    left_subs  = subs('--^---!')
    right_subs = subs('--^-----!')
    res = scheduler.configure { left.merge(right) }
    assert_msgs expected, res
    assert_subs left_subs, left
    assert_subs right_subs, right
  end
```

This PR deviates from the RxJS style in that it requires the expected value to be passed in parsed format, while RxJS has the expectations as strings. This is because existing RxRuby tests already use the `on_next` et al helpers in their expectations.

Some parts of the RxJS DSL is not yet implemented, notably groupings.

This PR also works around the fact that the TestScheduler increments by one to distinguish between events that are simultaneous by introducing a constructor argument to turn off this behavior. 