### PR TITLE
Cleanup amb operator

### DIFF
--- a/test/rx/operators/test_amb.rb
+++ b/test/rx/operators/test_amb.rb
@@ -1,58 +1,94 @@
 require 'test_helper'
 
 class TestOperatorAmb < Minitest::Test
-  include Rx::ReactiveTest
+  include Rx::MarbleTesting
+
+  def test_left_on_next_wins
+    left       = cold('  -1---|')
+    right      = cold('  --2-|')
+    expected   = msgs('---1---|')
+    left_subs  = subs('  ^    !')
+    right_subs = subs('  ^!')
+
+    actual = scheduler.configure { left.amb(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_left_on_error_wins
+    left       = cold('  -#')
+    right      = cold('  --2-|')
+    expected   = msgs('---#')
+    left_subs  = subs('  ^!')
+    right_subs = subs('  ^!')
+
+    actual = scheduler.configure { left.amb(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_left_on_completed_wins
+    left       = cold('  -|')
+    right      = cold('  --2-|')
+    expected   = msgs('---|')
+    left_subs  = subs('  ^!')
+    right_subs = subs('  ^!')
+
+    actual = scheduler.configure { left.amb(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_right_on_next_wins
+    left       = cold('  --2-|')
+    right      = cold('  -1---|')
+    expected   = msgs('---1---|')
+    left_subs  = subs('  ^!')
+    right_subs = subs('  ^    !')
+
+    actual = scheduler.configure { left.amb(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_right_on_error_wins
+    left       = cold('  --2-|')
+    right      = cold('  -#')
+    expected   = msgs('---#')
+    left_subs  = subs('  ^!')
+    right_subs = subs('  ^!')
+
+    actual = scheduler.configure { left.amb(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_right_on_completed_wins
+    left       = cold('  --2-|')
+    right      = cold('  -|')
+    expected   = msgs('---|')
+    left_subs  = subs('  ^!')
+    right_subs = subs('  ^!')
+
+    actual = scheduler.configure { left.amb(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
 
   def setup
     @scheduler = Rx::TestScheduler.new
-  end
-
-  def run_amb_test(winner, left_event, right_event)
-    left = @scheduler.create_cold_observable(
-      left_event
-    )
-    right = @scheduler.create_cold_observable(
-      right_event
-    )
-    res = @scheduler.configure do
-      left.amb(right)
-    end
-
-    if winner == :left
-      left_event.time += SUBSCRIBED
-      assert_messages [left_event], res.messages
-      assert_subscriptions [subscribe(200, 300)], left.subscriptions
-      assert_subscriptions [subscribe(200, 300)], right.subscriptions
-    else
-      right_event.time += SUBSCRIBED
-      assert_messages [right_event], res.messages
-      assert_subscriptions [subscribe(200, 300)], left.subscriptions
-      assert_subscriptions [subscribe(200, 300)], right.subscriptions
-    end
-  end
-
-  def test_amb_left_on_next_wins
-    run_amb_test(:left, on_next(100, 1), on_completed(200))
-  end
-
-  def test_amb_left_on_error_wins
-    run_amb_test(:left, on_error(100, 1), on_completed(200))
-  end
-
-  def test_amb_left_on_completed_wins
-    run_amb_test(:left, on_completed(100), on_next(200, 1))
-  end
-
-  def test_amb_right_on_next_wins
-    run_amb_test(:right, on_error(200, 1), on_next(100, 1))
-  end
-
-  def test_amb_right_on_error_wins
-    run_amb_test(:right, on_error(200, 1), on_error(100, 1))
-  end
-
-  def test_amb_right_on_completed_wins
-    run_amb_test(:right, on_completed(200), on_completed(100))
   end
 end
 

--- a/test/rx/operators/test_amb.rb
+++ b/test/rx/operators/test_amb.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+class TestOperatorAmb < Minitest::Test
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+  end
+
+  def run_amb_test(winner, left_event, right_event)
+    left = @scheduler.create_cold_observable(
+      left_event
+    )
+    right = @scheduler.create_cold_observable(
+      right_event
+    )
+    res = @scheduler.configure do
+      left.amb(right)
+    end
+    
+    if winner == :left
+      left_event.time += SUBSCRIBED
+      assert_messages [left_event], res.messages
+      assert_subscriptions [subscribe(200, 300)], left.subscriptions
+      assert_subscriptions [subscribe(200, 300)], right.subscriptions
+    else
+      right_event.time += SUBSCRIBED
+      assert_messages [right_event], res.messages
+      assert_subscriptions [subscribe(200, 300)], left.subscriptions
+      assert_subscriptions [subscribe(200, 300)], right.subscriptions
+    end
+  end
+
+  def test_amb_left_on_next_wins
+    run_amb_test(:left, on_next(100, 1), on_completed(200))
+  end
+
+  def test_amb_left_on_error_wins
+    run_amb_test(:left, on_error(100, 1), on_completed(200))
+  end
+
+  def test_amb_left_on_completed_wins
+    run_amb_test(:left, on_completed(100), on_next(200, 1))
+  end
+
+  def test_amb_right_on_next_wins
+    run_amb_test(:right, on_error(200, 1), on_next(100, 1))
+  end
+
+  def test_amb_right_on_error_wins
+    run_amb_test(:right, on_error(200, 1), on_error(100, 1))
+  end
+
+  def test_amb_right_on_completed_wins
+    run_amb_test(:right, on_completed(200), on_completed(100))
+  end
+end


### PR DESCRIPTION
Marble-style tests and mild concurrency testing.

Changelog:
- remove unnecessary helper class AmbObserver as it uses quite slow `method_missing?` introspection

