### PR TITLE
Cleanup .concat operator incl .for, .repeat, .start_with

### DIFF
--- a/lib/rx/linq/observable/for.rb
+++ b/lib/rx/linq/observable/for.rb
@@ -1,12 +1,14 @@
 module Rx
   class << Observable
-    def for(sources, result_selector = nil)
-      result_selector ||= lambda {|*args| args}
-      enum = ThreadedEnumerator.new {|y|
-        sources.each {|v|
-          y << result_selector.call(v)
+    def for(sources, &transform)
+      raise ArgumentError.new 'sources must be enumerable' unless sources.respond_to? :each
+      enum = if block_given?
+        ThreadedEnumerator.new {|y|
+          sources.each {|v| y << yield(v) }
         }
-      }
+      else
+        ThreadedEnumerator.new(sources)
+      end
       Observable.concat(enum)
     end
   end

--- a/lib/rx/operators/multiple.rb
+++ b/lib/rx/operators/multiple.rb
@@ -578,16 +578,13 @@ module Rx
                 break
               end
 
-              d = SingleAssignmentSubscription.new
-              subscription.subscription = d
-
               new_obs = Observer.configure do |o|
                 o.on_next(&observer.method(:on_next))
                 o.on_error(&observer.method(:on_error))
                 o.on_completed { this.call }
               end
 
-              current.subscribe new_obs
+              subscription.subscription = current.subscribe new_obs
             end
           }
 

--- a/lib/rx/operators/single.rb
+++ b/lib/rx/operators/single.rb
@@ -380,6 +380,7 @@ module Rx
     end
 
     def enumerator_repeat_times(num, value)
+      raise ArgumentError.new("Expected #{num} to be an integer") unless num.is_a? Integer
       ThreadedEnumerator.new do |y|
         num.times do |i|
           y << value

--- a/test/rx/linq/observable/test_for.rb
+++ b/test/rx/linq/observable/test_for.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class TestObservableFor < Minitest::Test
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+    @observer = @scheduler.create_observer
+    @err = RuntimeError.new
+  end
+
+  def test_for_array
+    res = @scheduler.configure do
+      Rx::Observable.for([1, 2, 3].map {|n| Rx::Observable.of(n) })
+    end
+
+    expected = [
+      on_next(SUBSCRIBED, 1),
+      on_next(SUBSCRIBED, 2),
+      on_next(SUBSCRIBED, 3),
+      on_completed(SUBSCRIBED)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_for_argument_error_on_nil
+    assert_raises(ArgumentError) do
+      Rx::Observable.for(nil)
+    end
+  end
+
+  def test_for_with_transform
+    res = @scheduler.configure do
+      Rx::Observable.for([1, 2, 3]) {|n| Rx::Observable.of(n) }
+    end
+
+    expected = [
+      on_next(SUBSCRIBED, 1),
+      on_next(SUBSCRIBED, 2),
+      on_next(SUBSCRIBED, 3),
+      on_completed(SUBSCRIBED)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  class ErroringEnumerable
+    def initialize(err)
+      @err = err
+    end
+
+    def each
+      raise @err
+    end
+  end
+
+  def test_for_with_erroring_enumerable
+    res = @scheduler.configure do
+      Rx::Observable.for(ErroringEnumerable.new(@err))
+    end
+    assert_messages [on_error(SUBSCRIBED, @err)], res.messages
+  end
+
+  def test_for_with_erroring_transform
+    res = @scheduler.configure do
+      Rx::Observable.for([Rx::Observable.of(1)]) {|n| raise @err }
+    end
+    assert_messages [on_error(SUBSCRIBED, @err)], res.messages
+  end
+end

--- a/test/rx/operators/test_concat.rb
+++ b/test/rx/operators/test_concat.rb
@@ -1,132 +1,99 @@
 require 'test_helper'
-require 'rx/testing/mock_observer'
 
 class TestOperatorConcat < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_concatenates_sequences
+    left       = cold('  -12|')
+    right      = cold('     -34|')
+    expected   = msgs('---12-34|')
+    left_subs  = subs('  ^  !')
+    right_subs = subs('     ^  !')
+
+    actual = scheduler.configure { left.concat(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_waits_for_each_observable_to_complete
+    left       = cold('  -12-')
+    right      = cold('     -34|')
+    expected   = msgs('---12----')
+    left_subs  = [subscribe(200, 4711)]
+    right_subs = subs('')
+
+    actual = scheduler.configure(disposed: 4711) { left.concat(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_concat_aborts_on_error
+    left       = cold('  -12#')
+    right      = cold('     -34|')
+    expected   = msgs('---12#')
+    left_subs  = subs('  ^  !')
+    right_subs = subs('')
+
+    actual = scheduler.configure { left.concat(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_accepts_enumerator
+    left       = cold('  -12|')
+    right      = cold('     -34|')
+    expected   = msgs('---12-34|')
+    left_subs  = subs('  ^  !')
+    right_subs = subs('     ^  !')
+
+    enum = Enumerator.new do |y|
+      y << left
+      y << right
+    end
+
+    actual = scheduler.configure { Rx::Observable.concat(enum) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_erroring_enumerator
+    expected = msgs('--#')
+    enum = Enumerator.new do |y|
+      raise error
+    end
+
+    actual = scheduler.configure { Rx::Observable.concat(enum) }
+
+    assert_msgs expected, actual
+  end
+end
+
+class TestConcurrencyConcat  < Minitest::Test
   include Rx::AsyncTesting
   include Rx::ReactiveTest
 
   def setup
-    @scheduler = Rx::TestScheduler.new
-    @observer = Rx::MockObserver.new(@scheduler)
-    @err = RuntimeError.new
-  end
-
-  def test_concatenates_sequences
-    res = @scheduler.configure do
-      @scheduler.create_cold_observable(
-        on_next(100, 1),
-        on_next(200, 2),
-        on_completed(300)
-      ).concat(
-        @scheduler.create_cold_observable(
-          on_next(100, 3),
-          on_next(200, 4),
-          on_completed(300)
-        )
-      )
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_next(SUBSCRIBED + 200, 2),
-      on_next(SUBSCRIBED + 400, 3),
-      on_next(SUBSCRIBED + 500, 4),
-      on_completed(SUBSCRIBED + 300 + 300)
-    ]
-    assert_messages expected, res.messages
-  end
-  
-  def test_subscribes_sequentially
-    left = @scheduler.create_cold_observable(
-      on_next(100, 1),
-      on_completed(200)
-    )
-    right = @scheduler.create_cold_observable(
-      on_next(100, 3),
-      on_completed(200)
-    )
-    @scheduler.configure do
-      left.concat(right)
-    end
-
-    assert_subscriptions [subscribe(200, 400)], left.subscriptions
-    assert_subscriptions [subscribe(400, 600)], right.subscriptions
-  end
-
-  def test_waits_for_each_observable_to_complete
-    res = @scheduler.configure do
-      @scheduler.create_cold_observable(
-        on_next(100, 1),
-      ).concat(
-        @scheduler.create_cold_observable(
-          on_next(100, 3),
-          on_completed(200)
-        )
-      )
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 1)
-    ]
-    assert_messages expected, res.messages
-  end
-
-  def test_concat_aborts_on_error
-    res = @scheduler.configure do
-      @scheduler.create_cold_observable(
-        on_next(100, 1),
-        on_error(200, @err)
-      ).concat(
-        @scheduler.create_cold_observable(
-          on_next(100, 3),
-          on_completed(200)
-        )
-      )
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_error(SUBSCRIBED + 200, @err)
-    ]
-    assert_messages expected, res.messages
-  end
-
-  def test_does_not_subscribe_right_on_previous_error
-    left = @scheduler.create_cold_observable(
-      on_error(100, @err)
-    )
-    right = @scheduler.create_cold_observable(
-      on_next(100, 3),
-      on_completed(200)
-    )
-    @scheduler.configure do
-      left.concat(right)
-    end
-
-    assert_subscriptions [], right.subscriptions
-  end
-
-  def thread_observable(side)
-    Rx::Observable.create do |o|
-      Thread.new do
-        sleep 0.01
-        3.times { o.on_next side }
-        o.on_completed
-      end
-    end
+    @observer = Rx::TestScheduler.new.create_observer
   end
 
   def test_observable_concat_concurrency
-    observables = 3.times.map {|n| thread_observable("thread-#{n}") }
-    mock = Rx::MockObserver.new(@scheduler)
-    Rx::Observable.concat(*observables).subscribe(mock)
-    await_array_length mock.messages, 10
+    observables = 3.times.map {|n| async_observable(*[on_next(0, "thread-#{n}")] * 3, on_completed(0)) }
+    Rx::Observable.concat(*observables).subscribe(@observer)
+    await_array_length @observer.messages, 10
     expected = [
       *([on_next(0, 'thread-0')] * 3),
       *([on_next(0, 'thread-1')] * 3),
       *([on_next(0, 'thread-2')] * 3),
       on_completed(0)
     ]
-    assert_messages expected, mock.messages
+    assert_messages expected, @observer.messages
   end
 end

--- a/test/rx/operators/test_concat.rb
+++ b/test/rx/operators/test_concat.rb
@@ -1,0 +1,132 @@
+require 'test_helper'
+require 'rx/testing/mock_observer'
+
+class TestOperatorConcat < Minitest::Test
+  include Rx::AsyncTesting
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+    @observer = Rx::MockObserver.new(@scheduler)
+    @err = RuntimeError.new
+  end
+
+  def test_concatenates_sequences
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_next(100, 1),
+        on_next(200, 2),
+        on_completed(300)
+      ).concat(
+        @scheduler.create_cold_observable(
+          on_next(100, 3),
+          on_next(200, 4),
+          on_completed(300)
+        )
+      )
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_next(SUBSCRIBED + 200, 2),
+      on_next(SUBSCRIBED + 400, 3),
+      on_next(SUBSCRIBED + 500, 4),
+      on_completed(SUBSCRIBED + 300 + 300)
+    ]
+    assert_messages expected, res.messages
+  end
+  
+  def test_subscribes_sequentially
+    left = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_completed(200)
+    )
+    right = @scheduler.create_cold_observable(
+      on_next(100, 3),
+      on_completed(200)
+    )
+    @scheduler.configure do
+      left.concat(right)
+    end
+
+    assert_subscriptions [subscribe(200, 400)], left.subscriptions
+    assert_subscriptions [subscribe(400, 600)], right.subscriptions
+  end
+
+  def test_waits_for_each_observable_to_complete
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_next(100, 1),
+      ).concat(
+        @scheduler.create_cold_observable(
+          on_next(100, 3),
+          on_completed(200)
+        )
+      )
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_concat_aborts_on_error
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_next(100, 1),
+        on_error(200, @err)
+      ).concat(
+        @scheduler.create_cold_observable(
+          on_next(100, 3),
+          on_completed(200)
+        )
+      )
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_error(SUBSCRIBED + 200, @err)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_does_not_subscribe_right_on_previous_error
+    left = @scheduler.create_cold_observable(
+      on_error(100, @err)
+    )
+    right = @scheduler.create_cold_observable(
+      on_next(100, 3),
+      on_completed(200)
+    )
+    @scheduler.configure do
+      left.concat(right)
+    end
+
+    assert_subscriptions [], right.subscriptions
+  end
+
+  def thread_observable(side)
+    Rx::Observable.create do |o|
+      Thread.new do
+        sleep 0.01
+        3.times { o.on_next side }
+        o.on_completed
+      end
+    end
+  end
+
+  def test_observable_concat_concurrency
+    observables = 3.times.map {|n| thread_observable("thread-#{n}") }
+    mock = Rx::MockObserver.new(@scheduler)
+    Rx::Observable.concat(*observables).subscribe(mock)
+    await_array_length mock.messages, 10
+    expected = [
+      *([on_next(0, 'thread-0')] * 3),
+      *([on_next(0, 'thread-1')] * 3),
+      *([on_next(0, 'thread-2')] * 3),
+      on_completed(0)
+    ]
+    assert_messages expected, mock.messages
+  end
+end

--- a/test/rx/operators/test_repeat.rb
+++ b/test/rx/operators/test_repeat.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+class TestOperatorRepeat < Minitest::Test
+  include Rx::AsyncTesting
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+    @observer = @scheduler.create_observer
+    @err = RuntimeError.new
+  end
+
+  def test_repeat
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_next(100, 1),
+        on_next(200, 2),
+        on_completed(300)
+      ).repeat(2)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_next(SUBSCRIBED + 200, 2),
+      on_next(SUBSCRIBED + 400, 1),
+      on_next(SUBSCRIBED + 500, 2),
+      on_completed(SUBSCRIBED + 600)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_repeat_stops_with_on_error
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_error(100, @err)
+      ).repeat(2)
+    end
+    expected = [
+      on_error(SUBSCRIBED + 100, @err)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_repeat_throws_argument_error_on_bad_count
+    assert_raises(ArgumentError) do
+      @scheduler.create_cold_observable(
+        on_completed(100)
+      ).repeat(nil)
+    end
+  end
+  
+  def test_repeat_infinitely
+    subscription = Rx::Observable.of(1, 2)
+      .repeat_infinitely
+      .subscribe_on(Rx::DefaultScheduler.instance)
+      .subscribe(@observer)
+    await_array_minimum_length(@observer.messages, 10)
+    subscription.unsubscribe
+    expected = ([
+      on_next(0, 1),
+      on_next(0, 2)
+    ] * 5).flatten
+    assert_messages expected, @observer.messages.take(10)
+  end
+  
+  def test_repeat_infinitely_breaks_on_error
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_error(100, @err)
+      ).repeat_infinitely
+    end
+    expected = [
+      on_error(SUBSCRIBED + 100, @err)
+    ]
+    assert_messages expected, res.messages
+  end
+end

--- a/test/rx/operators/test_start_with.rb
+++ b/test/rx/operators/test_start_with.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class TestOperatorStartWith < Minitest::Test
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+    @observer = @scheduler.create_observer
+    @err = RuntimeError.new
+    @left_completing = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_completed(200)
+    )
+    @left_erroring = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_error(200, @err)
+    )
+  end
+  
+  def test_start_with_prepends_values
+    res = @scheduler.configure do
+      @left_completing.start_with(0)
+    end
+    
+    expected = [
+      on_next(SUBSCRIBED, 0),
+      on_next(SUBSCRIBED + 100, 1),
+      on_completed(SUBSCRIBED + 200)
+    ]
+    assert_messages expected, res.messages
+  end
+  
+  def test_start_with_aborts_on_error_right
+    res = @scheduler.configure do
+      @left_erroring.start_with(0)
+    end
+    
+    expected = [
+      on_next(SUBSCRIBED, 0),
+      on_next(SUBSCRIBED + 100, 1),
+      on_error(SUBSCRIBED + 200, @err)
+    ]
+    assert_messages expected, res.messages
+  end
+end

--- a/test/rx/operators/test_start_with.rb
+++ b/test/rx/operators/test_start_with.rb
@@ -1,45 +1,27 @@
 require 'test_helper'
 
 class TestOperatorStartWith < Minitest::Test
-  include Rx::ReactiveTest
-
-  def setup
-    @scheduler = Rx::TestScheduler.new
-    @observer = @scheduler.create_observer
-    @err = RuntimeError.new
-    @left_completing = @scheduler.create_cold_observable(
-      on_next(100, 1),
-      on_completed(200)
-    )
-    @left_erroring = @scheduler.create_cold_observable(
-      on_next(100, 1),
-      on_error(200, @err)
-    )
-  end
+  include Rx::MarbleTesting
   
   def test_start_with_prepends_values
-    res = @scheduler.configure do
-      @left_completing.start_with(0)
-    end
-    
-    expected = [
-      on_next(SUBSCRIBED, 0),
-      on_next(SUBSCRIBED + 100, 1),
-      on_completed(SUBSCRIBED + 200)
-    ]
-    assert_messages expected, res.messages
+    source      = cold('  -2|')
+    expected    = msgs('--(1-)2|')
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure { source.start_with('1') }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
   end
   
   def test_start_with_aborts_on_error_right
-    res = @scheduler.configure do
-      @left_erroring.start_with(0)
-    end
-    
-    expected = [
-      on_next(SUBSCRIBED, 0),
-      on_next(SUBSCRIBED + 100, 1),
-      on_error(SUBSCRIBED + 200, @err)
-    ]
-    assert_messages expected, res.messages
+    source      = cold('  -2#')
+    expected    = msgs('--(1-)2#')
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure { source.start_with('1') }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
   end
 end


### PR DESCRIPTION
Marble-style tests for `.concat` and `.for`, `.repeat`, `.start_with` which use concat.

Changelog:
- `.concat` now unsubscribes sources when they are exhausted.
- `.for` block is a "transform", rather than a "result selector"
- ensure argument to `.repeat` is an integer