### PR TITLE
Fix rake dependency to retain 1.9 support

### DIFF
--- a/rx.gemspec
+++ b/rx.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'Apache License, v2.0'
 
   gem.add_development_dependency 'codecov'
-  gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'
+  gem.add_development_dependency 'rake', '= 12.2.0'
   gem.add_development_dependency 'simplecov'
 end


### PR DESCRIPTION
Fix to `rake = 12.2.0` as 12.3.0 explicitly requires Ruby 2+ and we want to retain 1.9 support. More info at https://github.com/ruby/rake/blob/master/History.rdoc.