### PR TITLE
Cleanup latest and friends

### DIFF
--- a/lib/rx/operators/multiple.rb
+++ b/lib/rx/operators/multiple.rb
@@ -308,12 +308,13 @@ module Rx
         other_subscription = SingleAssignmentSubscription.new
 
         open = false
+        other_completed = false
         gate = Monitor.new
 
         source_obs = Observer.configure do |o|
           o.on_next {|x| observer.on_next x if open }
           o.on_error(&observer.method(:on_error))
-          o.on_completed { observer.on_completed if open }
+          o.on_completed { observer.on_completed if open || other_completed }
         end
 
         other_obs = Observer.configure do |o|
@@ -323,6 +324,7 @@ module Rx
           end
 
           o.on_error(&observer.method(:on_error))
+          o.on_completed { other_completed = true }
         end
 
         source_subscription.subscription = synchronize(gate).subscribe(source_obs)

--- a/lib/rx/operators/multiple.rb
+++ b/lib/rx/operators/multiple.rb
@@ -613,7 +613,11 @@ module Rx
           next_action = lambda do |i|
             if queues.all? {|q| q.length > 0 }
               res = queues.map {|q| q.shift }
-              observer.on_next(result_selector.call(*res))
+              begin
+                observer.on_next(result_selector.call(*res))
+              rescue => e
+                observer.on_error e
+              end
             elsif enumerable_select_with_index(is_done) {|x, j| j != i } .all?
               observer.on_completed
             end

--- a/lib/rx/operators/multiple.rb
+++ b/lib/rx/operators/multiple.rb
@@ -617,15 +617,17 @@ module Rx
                 observer.on_next(result_selector.call(*res))
               rescue => e
                 observer.on_error e
+                break
               end
-            elsif enumerable_select_with_index(is_done) {|x, j| j != i } .all?
+            end
+            if queues.each_with_index.any? { |q, j| q.empty? && is_done[j] }
               observer.on_completed
             end
           end
 
           done = lambda do |i|
             is_done[i] = true
-            observer.on_completed if is_done.all?
+            observer.on_completed if queues[i].empty?
           end
 
           gate = Monitor.new

--- a/test/rx/operators/test_combine_latest.rb
+++ b/test/rx/operators/test_combine_latest.rb
@@ -1,0 +1,136 @@
+require 'test_helper'
+
+class TestObservableCombineLatest < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_emit_when_all_source_omitted_once
+    a        = cold('  -1----4|')
+    b        = cold('  --2--5|')
+    c        = cold('  ---36|')
+    expected = msgs('-----abcd|', a: %w[1 2 3], b: %w[1 2 6], c: %w[1 5 6], d: %w[4 5 6])
+    a_subs   = subs('--^------!')
+    b_subs   = subs('--^-----!')
+    c_subs   = subs('--^----!')
+
+    actual = scheduler.configure do
+      Rx::Observable.combine_latest(a, b, c)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs c_subs, c
+  end
+
+  def test_emit_only_latest_from_each_source
+    a        = cold('  -123--|')
+    b        = cold('  ----4-|')
+    expected = msgs('------a-|', a: %w[3 4])
+    a_subs   = subs('--^-----!')
+    b_subs   = subs('--^-----!')
+
+    actual = scheduler.configure do
+      Rx::Observable.combine_latest(a, b)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_retain_last_for_completed_sources
+    a        = cold('  -1-----5|')
+    b        = cold('  --2--4|')
+    c        = cold('  ---3|')
+    expected = msgs('-----a-b-c|', a: %w[1 2 3], b: %w[1 4 3], c: %w[5 4 3])
+    a_subs   = subs('--^-------!')
+    b_subs   = subs('--^-----!')
+    c_subs   = subs('--^---!')
+
+    actual = scheduler.configure(disposed: 2000) do
+      Rx::Observable.combine_latest(a, b, c)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs c_subs, c
+  end
+
+  def test_source_error_is_propagated
+    a        = cold('  -1--|')
+    b        = cold('  --#')
+    expected = msgs('----#')
+    a_subs   = subs('--^-!')
+    b_subs   = subs('--^-!')
+
+    actual = scheduler.configure do
+      Rx::Observable.combine_latest(a, b)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_completes_immediately_on_empty_source
+    a        = cold('  -|')
+    expected = msgs('---|')
+    a_subs   = subs('--^!')
+
+    actual = scheduler.configure do
+      Rx::Observable.combine_latest(a)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+  end
+
+  def test_completes_without_emitting_when_some_emits
+    a        = cold('  -1-2-|')
+    b        = cold('  --|')
+    expected = msgs('-----|')
+    a_subs   = subs('--^--!')
+    b_subs   = subs('--^-!')
+
+    actual = scheduler.configure do
+      Rx::Observable.combine_latest(a, b)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_apply_selector_before_emission
+    a        = cold('  -123--|')
+    b        = cold('  ----4-|')
+    expected = msgs('------7-|')
+    a_subs   = subs('--^-----!')
+    b_subs   = subs('--^-----!')
+
+    actual = scheduler.configure do
+      Rx::Observable.combine_latest(a, b) { |*values| values.map(&:to_i).inject(0, :+).to_s }
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_propagate_error_raised_in_selector
+    a        = cold('  -123--|')
+    b        = cold('  ----4-|')
+    expected = msgs('------#')
+    a_subs   = subs('--^---!')
+    b_subs   = subs('--^---!')
+
+    actual = scheduler.configure do
+      Rx::Observable.combine_latest(a, b) { |_| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+end

--- a/test/rx/operators/test_combine_latest.rb
+++ b/test/rx/operators/test_combine_latest.rb
@@ -1,5 +1,25 @@
 require 'test_helper'
 
+class TestCombineLatest < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_apply_selector_before_emission
+    left         = cold('  -123--|')
+    right        = cold('  ----4-|')
+    expected     = msgs('------7-|')
+    left_subs    = subs('--^-----!')
+    right_subs   = subs('--^-----!')
+
+    actual = scheduler.configure do
+      left.combine_latest(right) { |*values| values.map(&:to_i).inject(0, :+).to_s }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+end
+
 class TestObservableCombineLatest < Minitest::Test
   include Rx::MarbleTesting
 

--- a/test/rx/operators/test_latest.rb
+++ b/test/rx/operators/test_latest.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+class TestOperatorLatest < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_latest_inner_observable_on_next
+    a        = cold('  -1-4|')
+    b        = cold('    -2-5|')
+    c        = cold('      -3|')
+    left     = cold('  a-b-c|', a: a, b: b, c: c)
+    expected = msgs('---1-2-3|')
+    a_subs   = subs('--^-!')
+    b_subs   = subs('----^-!')
+    c_subs   = subs('------^-!')
+
+    actual = scheduler.configure { left.latest }
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs c_subs, c
+  end
+
+  def test_silent_observable_subscribe_unsubscribe
+    a        = cold('  -1-|')
+    b        = cold('    ---|')
+    c        = cold('      -2|')
+    left     = cold('  a-b-c|', a: a, b: b, c: c)
+    expected = msgs('---1---2|')
+    a_subs   = subs('--^-!')
+    b_subs   = subs('----^-!')
+    c_subs   = subs('------^-!')
+
+    actual = scheduler.configure { left.latest }
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs c_subs, c
+  end
+
+  def test_erroring_inner_propagates_error
+    a        = cold('  -1#')
+    b        = cold('     -2|')
+    left     = cold('  a--b|', a: a, b: b)
+    expected = msgs('---1#')
+    a_subs   = subs('--^-!')
+    b_subs   = subs('')
+
+    actual = scheduler.configure { left.latest }
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_disjunct_inner_completing_observables
+    a        = cold('  -1|')
+    b        = cold('      -2|')
+    left     = cold('  a---b--|', a: a, b: b)
+    expected = msgs('---1---2-|')
+    a_subs   = subs('  ^ !')
+    b_subs   = subs('      ^ !')
+
+    actual = scheduler.configure { left.latest }
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_waiting_for_first_inner_observable
+    a        = cold('     -1|')
+    left     = cold('  ---a---|', a: a)
+    expected = msgs('------1--|')
+    a_subs   = subs('     ^ !')
+
+    actual = scheduler.configure { left.latest }
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+  end
+end

--- a/test/rx/operators/test_skip_until.rb
+++ b/test/rx/operators/test_skip_until.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class TestOperatorSkipUntil < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_skip_left_until_right_emits
+    left       = cold('  a-b-c-d|')
+    right      = cold('  ---1----')
+    expected   = msgs('------c-d|')
+    left_subs  = subs('  ^      !')
+    right_subs = subs('  ^  !')
+
+    actual = scheduler.configure { left.skip_until(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_propagate_left_error
+    left       = cold('  a-#')
+    right      = cold('  ---')
+    expected   = msgs('----#')
+    left_subs  = subs('  ^ !')
+    right_subs = subs('  ^ !')
+
+    actual = scheduler.configure { left.skip_until(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_no_complete_on_infinite_right
+    left       = cold('  a-b-c|')
+    right      = cold('  ------')
+    expected   = msgs('--------')
+    left_subs  = subs('  ^    !')
+    right_subs = [subscribe(200, 4711)]
+
+    actual = scheduler.configure(disposed: 4711) { left.skip_until(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_propagates_right_error
+    left       = cold('  a-b-c|')
+    right      = cold('  -----#')
+    expected   = msgs('-------#')
+    left_subs  = subs('  ^    !')
+    right_subs = subs('  ^    !')
+
+    actual = scheduler.configure { left.skip_until(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_ignores_completing_right
+    left       = cold('  a-b-c|')
+    right      = cold('  ---|')
+    expected   = msgs('-------|')
+    left_subs  = subs('  ^    !')
+    right_subs = subs('  ^  !')
+
+    actual = scheduler.configure { left.skip_until(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+end

--- a/test/rx/operators/test_take_until.rb
+++ b/test/rx/operators/test_take_until.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class TestOperatorTakeUntil < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_propagates_left_event
+    left       = cold('  a-b-c|')
+    right      = cold('  ------')
+    expected   = msgs('--a-b-c|')
+    left_subs  = subs('  ^    !')
+    right_subs = subs('  ^    !')
+
+    actual = scheduler.configure { left.take_until(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_propagates_left_error
+    left       = cold('  a-b#')
+    right      = cold('  ----')
+    expected   = msgs('--a-b#')
+    left_subs  = subs('  ^  !')
+    right_subs = subs('  ^  !')
+
+    actual = scheduler.configure { left.take_until(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_completes_on_right_event
+    left       = cold('  a-b-c|')
+    right      = cold('  ---1-|')
+    expected   = msgs('--a-b|')
+    left_subs  = subs('--^--!')
+    right_subs = subs('--^--!')
+
+    actual = scheduler.configure { left.take_until(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_propagate_right_error
+    left       = cold('  a-b-c|')
+    right      = cold('  ---#-|')
+    expected   = msgs('--a-b#')
+    left_subs  = subs('--^--!')
+    right_subs = subs('--^--!')
+
+    actual = scheduler.configure { left.take_until(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_ignore_completing_right
+    left       = cold('  a-b-c|')
+    right      = cold('  ---|')
+    expected   = msgs('--a-b-c|')
+    left_subs  = subs('--^----!')
+    right_subs = subs('--^--!')
+
+    actual = scheduler.configure { left.take_until(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+end

--- a/test/rx/operators/test_zip.rb
+++ b/test/rx/operators/test_zip.rb
@@ -1,0 +1,154 @@
+require 'test_helper'
+
+class TestOperatorZip < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_emit_pairs_in_arrival_order
+    a        = cold('  -12-3-|')
+    b        = cold('  ---4-5|')
+    expected = msgs('-----a-b|', a: %w[1 4], b: %w[2 5])
+    a_subs   = subs('--^-----!')
+    b_subs   = subs('--^-----!')
+
+    actual = scheduler.configure { a.zip(b) }
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+end
+
+class TestObservableZip < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_emit_when_all_source_omitted_once
+    a        = cold('  -1----4|')
+    b        = cold('  --2--5-|')
+    c        = cold('  ---36--|')
+    expected = msgs('-----a--b|', a: %w[1 2 3], b: %w[4 5 6])
+    a_subs   = subs('--^------!')
+    b_subs   = subs('--^------!')
+    c_subs   = subs('--^------!')
+
+    actual = scheduler.configure do
+      Rx::Observable.zip(a, b, c)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs c_subs, c
+  end
+
+  def test_emit_pairs_in_arrival_order
+    a        = cold('  -12-3-|')
+    b        = cold('  ---4-5|')
+    expected = msgs('-----a-b|', a: %w[1 4], b: %w[2 5])
+    a_subs   = subs('--^-----!')
+    b_subs   = subs('--^-----!')
+
+    actual = scheduler.configure do
+      Rx::Observable.zip(a, b)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_complete_when_first_completes_no_buffers
+    a        = cold('  -1-|')
+    b        = cold('  --2-|')
+    expected = msgs('----a|', a: %w[1 2])
+    a_subs   = subs('--^--!')
+    b_subs   = subs('--^--!')
+
+    actual = scheduler.configure do
+      Rx::Observable.zip(a, b)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_complete_when_first_complete_and_queue_empty
+    a        = cold('  -12|')
+    b        = cold('  ---34--|')
+    expected = msgs('-----a(b|)', a: %w[1 3], b: %w[2 4])
+    a_subs   = subs('--^--!')
+    b_subs   = subs('--^---!')
+
+    actual = scheduler.configure do
+      Rx::Observable.zip(a, b)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_propagate_error_from_when_no_buffer
+    a        = cold('  -1---|')
+    b        = cold('  --2#')
+    expected = msgs('----a#', a: %w[1 2])
+    a_subs   = subs('--^--!')
+    b_subs   = subs('--^--!')
+
+    actual = scheduler.configure do
+      Rx::Observable.zip(a, b)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_propagate_error_from_when_when_buffered
+    a        = cold('  -1-2--|')
+    b        = cold('  --3-#')
+    expected = msgs('----a-#', a: %w[1 3])
+    a_subs   = subs('--^---!')
+    b_subs   = subs('--^---!')
+
+    actual = scheduler.configure do
+      Rx::Observable.zip(a, b)
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_apply_selector_before_emission
+    a        = cold('  -1-|')
+    b        = cold('  --2-|')
+    expected = msgs('----3|')
+    a_subs   = subs('--^--!')
+    b_subs   = subs('--^--!')
+
+    actual = scheduler.configure do
+      Rx::Observable.zip(a, b) { |*values| values.map(&:to_i).inject(0, :+).to_s }
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+
+  def test_propagate_error_raised_in_selector
+    a        = cold('  -123--|')
+    b        = cold('  ----4-|')
+    expected = msgs('------#')
+    a_subs   = subs('--^---!')
+    b_subs   = subs('--^---!')
+
+    actual = scheduler.configure do
+      Rx::Observable.zip(a, b) { |_| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+  end
+end


### PR DESCRIPTION
Marble-style tests for .combine_latest, .latest, .skip_until, .take_until, .zip.

Changelog:
- Remove buggy instance version of .combine_latest in favour of delegating to class-level .combine_latest
- .latest needs to unsubscribe inner observables
- .latest should only complete when both outer and inner observable has completed
- .skip_until should complete if other completed without emission
- .zip needs to catch errors in result selector
- .zip should complete as soon as there is no chance of another pair, i.e. when one source has been exhausted and has completed.