### PR TITLE
Cleanup merge

### DIFF
--- a/lib/rx/operators/multiple.rb
+++ b/lib/rx/operators/multiple.rb
@@ -532,7 +532,11 @@ module Rx
       end
 
       # Merges elements from all observable sequences in the given enumerable sequence into a single observable sequence, limiting the number of concurrent subscriptions to inner sequences, and using the specified scheduler for enumeration of and subscription to the sources.
-      def merge_concurrent(max_concurrent, scheduler = CurrentThreadScheduler.instance, *args)
+      def merge_concurrent(max_concurrent, *args)
+        scheduler = CurrentThreadScheduler.instance
+        if args.size > 0 && Scheduler === args[0]
+          scheduler = args.shift
+        end
         Observable.from_array(args, scheduler).merge_concurrent(max_concurrent)
       end
 

--- a/test/rx/operators/test_merge.rb
+++ b/test/rx/operators/test_merge.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+class TestOperatorMerge < Minitest::Test
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+    @observer = Rx::MockObserver.new(@scheduler)
+    @err = RuntimeError.new
+  end
+
+  def test_merge_two_sequences_in_order_of_arrival
+    left = @scheduler.create_cold_observable(
+      on_next(300, 1),
+      on_completed(400)
+    )
+    right = @scheduler.create_cold_observable(
+      on_next(100, 2),
+      on_next(200, 2),
+      on_next(500, 2),
+      on_completed(600)
+    )
+    res = @scheduler.configure do
+      left.merge(right)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 2),
+      on_next(SUBSCRIBED + 200, 2),
+      on_next(SUBSCRIBED + 300, 1),
+      on_next(SUBSCRIBED + 500, 2),
+      on_completed(SUBSCRIBED + 600)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_merge_no_complete_unless_all_complete
+    left = @scheduler.create_cold_observable(
+      on_next(300, 1),
+      on_completed(400)
+    )
+    right = @scheduler.create_cold_observable(
+      on_next(100, 2),
+      on_next(200, 2)
+    )
+    res = @scheduler.configure do
+      left.merge(right)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 2),
+      on_next(SUBSCRIBED + 200, 2),
+      on_next(SUBSCRIBED + 300, 1)
+    ]
+    assert_messages expected, res.messages
+    assert_subscriptions [subscribe(SUBSCRIBED, 1000)], right.subscriptions
+  end
+
+  def test_merge_on_error_left
+    left = @scheduler.create_cold_observable(
+      on_error(200, @err)
+    )
+    right = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_next(300, 1)
+    )
+    res = @scheduler.configure do
+      left.merge(right)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_error(SUBSCRIBED + 200, @err)
+    ]
+    assert_messages expected, res.messages
+    expected = [
+      subscribe(SUBSCRIBED, SUBSCRIBED + 200)
+    ]
+    assert_subscriptions expected, right.subscriptions
+  end
+end

--- a/test/rx/operators/test_merge.rb
+++ b/test/rx/operators/test_merge.rb
@@ -1,81 +1,40 @@
 require 'test_helper'
 
 class TestOperatorMerge < Minitest::Test
-  include Rx::ReactiveTest
-
-  def setup
-    @scheduler = Rx::TestScheduler.new
-    @observer = Rx::MockObserver.new(@scheduler)
-    @err = RuntimeError.new
-  end
+  include Rx::MarbleTesting
 
   def test_merge_two_sequences_in_order_of_arrival
-    left = @scheduler.create_cold_observable(
-      on_next(300, 1),
-      on_completed(400)
-    )
-    right = @scheduler.create_cold_observable(
-      on_next(100, 2),
-      on_next(200, 2),
-      on_next(500, 2),
-      on_completed(600)
-    )
-    res = @scheduler.configure do
-      left.merge(right)
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 2),
-      on_next(SUBSCRIBED + 200, 2),
-      on_next(SUBSCRIBED + 300, 1),
-      on_next(SUBSCRIBED + 500, 2),
-      on_completed(SUBSCRIBED + 600)
-    ]
-    assert_messages expected, res.messages
+    left       = cold('  ---c|')
+    right      = cold('  -ab--d|')
+    expected   = msgs('---abc-d|')
+    left_subs  = subs('--^---!')
+    right_subs = subs('--^-----!')
+    res = scheduler.configure { left.merge(right) }
+    assert_msgs expected, res
+    assert_subs left_subs, left
+    assert_subs right_subs, right
   end
 
   def test_merge_no_complete_unless_all_complete
-    left = @scheduler.create_cold_observable(
-      on_next(300, 1),
-      on_completed(400)
-    )
-    right = @scheduler.create_cold_observable(
-      on_next(100, 2),
-      on_next(200, 2)
-    )
-    res = @scheduler.configure do
-      left.merge(right)
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 2),
-      on_next(SUBSCRIBED + 200, 2),
-      on_next(SUBSCRIBED + 300, 1)
-    ]
-    assert_messages expected, res.messages
-    assert_subscriptions [subscribe(SUBSCRIBED, 1000)], right.subscriptions
+    left       = cold('  ---c|')
+    right      = cold('  -ab')
+    expected   = msgs('---abc-')
+    right_subs = subs('--^-------!')
+    res = scheduler.configure { left.merge(right) }
+    assert_msgs expected, res
+    assert_subs right_subs, right
   end
 
-  def test_merge_on_error_left
-    left = @scheduler.create_cold_observable(
-      on_error(200, @err)
-    )
-    right = @scheduler.create_cold_observable(
-      on_next(100, 1),
-      on_next(300, 1)
-    )
-    res = @scheduler.configure do
-      left.merge(right)
-    end
+  def test_unsusbscribe_all_on_erroring_left
+    left       = cold('  --#')
+    right      = cold('  -a-b')
+    expected   = msgs('---a#')
+    left_subs  = subs('--^-!')
+    right_subs = subs('--^-!')
+    res = scheduler.configure { left.merge(right) }
 
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_error(SUBSCRIBED + 200, @err)
-    ]
-    assert_messages expected, res.messages
-    expected = [
-      subscribe(SUBSCRIBED, SUBSCRIBED + 200)
-    ]
-    assert_subscriptions expected, right.subscriptions
+    assert_msgs expected, res
+    assert_subs left_subs, left
+    assert_subs right_subs, right
   end
 end

--- a/test/rx/operators/test_merge_concurrent.rb
+++ b/test/rx/operators/test_merge_concurrent.rb
@@ -1,0 +1,206 @@
+require 'test_helper'
+
+class TestOperatorMergeConcurrent < Minitest::Test
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+    @observer = Rx::MockObserver.new(@scheduler)
+    @err = RuntimeError.new
+  end
+
+  def test_merge_three_sequences_two_at_a_time
+    no1 = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_completed(200)
+    )
+    no2 = @scheduler.create_cold_observable(
+      on_next(100, 2),
+      on_completed(200)
+    )
+    no3 = @scheduler.create_cold_observable(
+      on_next(100, 3),
+      on_completed(200)
+    )
+    no1_start, no2_start, no3_start = [50, 100, 150]
+
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_next(no1_start, no1),
+        on_next(no2_start, no2),
+        on_next(no3_start, no3),
+        on_completed(no3_start + 50)
+      ).merge_concurrent(2)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + no1_start + 100, 1),
+      on_next(SUBSCRIBED + no2_start + 100, 2),
+      on_next(SUBSCRIBED + no1_start + 200 + 100, 3),
+      on_completed(SUBSCRIBED + no1_start + 200 + 200)
+    ]
+    assert_messages expected, res.messages
+    expected = [
+      subscribe(SUBSCRIBED + no1_start, SUBSCRIBED + no1_start + 200)
+    ]
+    assert_subscriptions expected, no1.subscriptions
+    expected = [
+      subscribe(SUBSCRIBED + no2_start, SUBSCRIBED + no2_start + 200)
+    ]
+    assert_subscriptions expected, no2.subscriptions
+    expected = [
+      subscribe(SUBSCRIBED + no1_start + 200, SUBSCRIBED + no1_start + 400)
+    ]
+    assert_subscriptions expected, no3.subscriptions
+  end
+
+  def test_error_stops_later_subscription
+    no1 = @scheduler.create_cold_observable(
+      on_completed(200)
+    )
+    no2 = @scheduler.create_cold_observable(
+      on_error(100, @err)
+    )
+    no3 = @scheduler.create_cold_observable(
+      on_next(150, 3),
+      on_completed(200)
+    )
+
+    no1_start, no2_start, no3_start = [50, 100, 150]
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable( # 200
+        on_next(no1_start, no1), # 250, 450
+        on_next(no2_start, no2), # 300, 400
+        on_next(no3_start, no3), # 350, 500, 550
+        on_completed(no3_start + 100), # 450
+      ).merge_concurrent(2)
+    end
+
+    expected = [
+      on_error(SUBSCRIBED + no2_start + 100, @err)
+    ]
+    assert_messages expected, res.messages
+    expected = [
+      subscribe(SUBSCRIBED + no1_start, SUBSCRIBED + no2_start + 100)
+    ]
+    assert_subscriptions expected, no1.subscriptions
+    expected = [
+      subscribe(SUBSCRIBED + no2_start, SUBSCRIBED + no2_start + 100)
+    ]
+    assert_subscriptions expected, no2.subscriptions
+    assert_subscriptions [], no3.subscriptions
+  end
+
+  def test_handles_concurrency_exceeding_emissions
+    no1 = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_completed(200)
+    )
+    no2 = @scheduler.create_cold_observable(
+      on_next(100, 2),
+      on_completed(200)
+    )
+
+    no1_start, no2_start = [100, 200]
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_next(no1_start, no1),
+        on_next(no2_start, no2),
+        on_completed(no2_start + 300)
+      ).merge_concurrent(5)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + no1_start + 100, 1),
+      on_next(SUBSCRIBED + no2_start + 100, 2),
+      on_completed(SUBSCRIBED + no1_start + 200 + 200)
+    ]
+    assert_messages expected, res.messages
+    expected = [
+      subscribe(SUBSCRIBED + no1_start, SUBSCRIBED + no1_start + 200)
+    ]
+    assert_subscriptions expected, no1.subscriptions
+    expected = [
+      subscribe(SUBSCRIBED + no2_start, SUBSCRIBED + no2_start + 200)
+    ]
+    assert_subscriptions expected, no2.subscriptions
+  end
+
+  def test_handles_single_emission
+    no1 = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_completed(200)
+    )
+    no1_start = 100
+    res = @scheduler.configure do
+      @scheduler.create_cold_observable(
+        on_next(no1_start, no1),
+        on_completed(200)
+      ).merge_concurrent(2)
+    end
+    expected = [
+      on_next(SUBSCRIBED + no1_start + 100, 1),
+      on_completed(SUBSCRIBED + no1_start + 200)
+    ]
+    assert_messages expected, res.messages
+    expected = [
+      subscribe(SUBSCRIBED + no1_start, SUBSCRIBED + no1_start + 200)
+    ]
+    assert_subscriptions expected, no1.subscriptions
+  end
+
+  def test_handles_empty_stream
+    no1 = @scheduler.create_cold_observable(
+      on_completed(100)
+    )
+    @scheduler.configure do
+      no1.merge_concurrent(2)
+    end
+    expected = [
+      subscribe(SUBSCRIBED, SUBSCRIBED + 100)
+    ]
+    assert_subscriptions expected, no1.subscriptions
+  end
+
+  def test_fail_on_bad_concurrency
+    assert_raises(ArgumentError) do
+      Rx::Observable.empty.merge_concurrent(nil)
+    end
+  end
+end
+
+class TestObservableMergeConcurrent < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_merge_three_sequences_two_at_a_time
+    a        = cold('  -1-|')
+    b        = cold('  --2|')
+    c        = cold('     -3|')
+    expected = msgs('---12-3|')
+    a_subs   = subs('--^--!')
+    b_subs   = subs('--^--!')
+    c_subs   = subs('-----^-!')
+
+    actual = scheduler.configure { Rx::Observable.merge_concurrent(2, a, b, c) }
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs c_subs, c
+  end
+
+  def test_accepts_scheduler_as_second_argument
+    a        = cold('  -1-|')
+    expected = msgs('---1-|')
+    actual = scheduler.configure do
+      Rx::Observable.merge_concurrent(2, Rx::ImmediateScheduler.instance, a)
+    end
+    assert_msgs expected, actual
+  end
+
+  def test_fail_on_bad_concurrency
+    assert_raises(ArgumentError) do
+      Rx::Observable.empty.merge_concurrent(nil)
+    end
+  end
+end

--- a/test/rx/operators/test_merge_concurrent.rb
+++ b/test/rx/operators/test_merge_concurrent.rb
@@ -1,165 +1,74 @@
 require 'test_helper'
 
 class TestOperatorMergeConcurrent < Minitest::Test
-  include Rx::ReactiveTest
-
-  def setup
-    @scheduler = Rx::TestScheduler.new
-    @observer = Rx::MockObserver.new(@scheduler)
-    @err = RuntimeError.new
-  end
+  include Rx::MarbleTesting
 
   def test_merge_three_sequences_two_at_a_time
-    no1 = @scheduler.create_cold_observable(
-      on_next(100, 1),
-      on_completed(200)
-    )
-    no2 = @scheduler.create_cold_observable(
-      on_next(100, 2),
-      on_completed(200)
-    )
-    no3 = @scheduler.create_cold_observable(
-      on_next(100, 3),
-      on_completed(200)
-    )
-    no1_start, no2_start, no3_start = [50, 100, 150]
+    a        = cold('  -1-|')
+    b        = cold('   -2|')
+    c        = cold('     -3|')
+    left     = cold('  abc|', a: a, b: b, c: c)
+    expected = msgs('---12-3|')
+    a_subs   = subs('--^--!')
+    b_subs   = subs('---^-!')
+    c_subs   = subs('-----^-!')
 
-    res = @scheduler.configure do
-      @scheduler.create_cold_observable(
-        on_next(no1_start, no1),
-        on_next(no2_start, no2),
-        on_next(no3_start, no3),
-        on_completed(no3_start + 50)
-      ).merge_concurrent(2)
-    end
+    res = scheduler.configure { left.merge_concurrent(2) }
 
-    expected = [
-      on_next(SUBSCRIBED + no1_start + 100, 1),
-      on_next(SUBSCRIBED + no2_start + 100, 2),
-      on_next(SUBSCRIBED + no1_start + 200 + 100, 3),
-      on_completed(SUBSCRIBED + no1_start + 200 + 200)
-    ]
-    assert_messages expected, res.messages
-    expected = [
-      subscribe(SUBSCRIBED + no1_start, SUBSCRIBED + no1_start + 200)
-    ]
-    assert_subscriptions expected, no1.subscriptions
-    expected = [
-      subscribe(SUBSCRIBED + no2_start, SUBSCRIBED + no2_start + 200)
-    ]
-    assert_subscriptions expected, no2.subscriptions
-    expected = [
-      subscribe(SUBSCRIBED + no1_start + 200, SUBSCRIBED + no1_start + 400)
-    ]
-    assert_subscriptions expected, no3.subscriptions
+    assert_msgs expected, res
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs c_subs, c
   end
 
   def test_error_stops_later_subscription
-    no1 = @scheduler.create_cold_observable(
-      on_completed(200)
-    )
-    no2 = @scheduler.create_cold_observable(
-      on_error(100, @err)
-    )
-    no3 = @scheduler.create_cold_observable(
-      on_next(150, 3),
-      on_completed(200)
-    )
+    a        = cold('  -1-|')
+    b        = cold('   -#')
+    c        = cold('    -3|')
+    left     = cold('  abc|', a: a, b: b, c: c)
+    expected = msgs('---1#')
+    a_subs   = subs('--^-!')
+    b_subs   = subs('---^!')
+    c_subs   = subs('')
 
-    no1_start, no2_start, no3_start = [50, 100, 150]
-    res = @scheduler.configure do
-      @scheduler.create_cold_observable( # 200
-        on_next(no1_start, no1), # 250, 450
-        on_next(no2_start, no2), # 300, 400
-        on_next(no3_start, no3), # 350, 500, 550
-        on_completed(no3_start + 100), # 450
-      ).merge_concurrent(2)
-    end
+    res = scheduler.configure { left.merge_concurrent(2) }
 
-    expected = [
-      on_error(SUBSCRIBED + no2_start + 100, @err)
-    ]
-    assert_messages expected, res.messages
-    expected = [
-      subscribe(SUBSCRIBED + no1_start, SUBSCRIBED + no2_start + 100)
-    ]
-    assert_subscriptions expected, no1.subscriptions
-    expected = [
-      subscribe(SUBSCRIBED + no2_start, SUBSCRIBED + no2_start + 100)
-    ]
-    assert_subscriptions expected, no2.subscriptions
-    assert_subscriptions [], no3.subscriptions
+    assert_msgs expected, res
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs c_subs, c
   end
 
   def test_handles_concurrency_exceeding_emissions
-    no1 = @scheduler.create_cold_observable(
-      on_next(100, 1),
-      on_completed(200)
-    )
-    no2 = @scheduler.create_cold_observable(
-      on_next(100, 2),
-      on_completed(200)
-    )
+    a        = cold('  -1|')
+    b        = cold('   --2|')
+    left     = cold('  ab|', a: a, b: b)
+    expected = msgs('---1-2|')
+    a_subs   = subs('--^-!')
+    b_subs   = subs('---^--!')
 
-    no1_start, no2_start = [100, 200]
-    res = @scheduler.configure do
-      @scheduler.create_cold_observable(
-        on_next(no1_start, no1),
-        on_next(no2_start, no2),
-        on_completed(no2_start + 300)
-      ).merge_concurrent(5)
-    end
+    res = scheduler.configure { left.merge_concurrent(5) }
 
-    expected = [
-      on_next(SUBSCRIBED + no1_start + 100, 1),
-      on_next(SUBSCRIBED + no2_start + 100, 2),
-      on_completed(SUBSCRIBED + no1_start + 200 + 200)
-    ]
-    assert_messages expected, res.messages
-    expected = [
-      subscribe(SUBSCRIBED + no1_start, SUBSCRIBED + no1_start + 200)
-    ]
-    assert_subscriptions expected, no1.subscriptions
-    expected = [
-      subscribe(SUBSCRIBED + no2_start, SUBSCRIBED + no2_start + 200)
-    ]
-    assert_subscriptions expected, no2.subscriptions
+    assert_msgs expected, res
+    assert_subs a_subs, a
+    assert_subs b_subs, b
   end
 
   def test_handles_single_emission
-    no1 = @scheduler.create_cold_observable(
-      on_next(100, 1),
-      on_completed(200)
-    )
-    no1_start = 100
-    res = @scheduler.configure do
-      @scheduler.create_cold_observable(
-        on_next(no1_start, no1),
-        on_completed(200)
-      ).merge_concurrent(2)
-    end
-    expected = [
-      on_next(SUBSCRIBED + no1_start + 100, 1),
-      on_completed(SUBSCRIBED + no1_start + 200)
-    ]
-    assert_messages expected, res.messages
-    expected = [
-      subscribe(SUBSCRIBED + no1_start, SUBSCRIBED + no1_start + 200)
-    ]
-    assert_subscriptions expected, no1.subscriptions
+    a        = cold('   -1|')
+    left     = cold('  -a|', a: a)
+    expected = msgs('----1|')
+    a_subs   = subs('---^-!')
+
+    res = scheduler.configure { left.merge_concurrent(2) }
+    assert_msgs expected, res
+    assert_subs a_subs, a
   end
 
   def test_handles_empty_stream
-    no1 = @scheduler.create_cold_observable(
-      on_completed(100)
-    )
-    @scheduler.configure do
-      no1.merge_concurrent(2)
-    end
-    expected = [
-      subscribe(SUBSCRIBED, SUBSCRIBED + 100)
-    ]
-    assert_subscriptions expected, no1.subscriptions
+    empty = cold('-|')
+    scheduler.configure { empty.merge_concurrent(2) }
+    assert_subs subs('--^!'), empty
   end
 
   def test_fail_on_bad_concurrency


### PR DESCRIPTION
Marble-style tests for `.merge`/`.merge_all` and `.merge_concurrent`.

Changelog:
- .merge now propagates unsubscribes to inner observables
- .merge_concurrent validates that max_concurrency is integer
- .merge_concurrent now propagates unsubscribes to inner observables
- .merge_concurrent class version can now be called without scheduler argument as intended