### PR TITLE
Cleanup .rescue_error operator, incl .retry, .retry_infinitely, .on_error_resume_next

### DIFF
--- a/lib/rx/operators/multiple.rb
+++ b/lib/rx/operators/multiple.rb
@@ -72,7 +72,7 @@ module Rx
     # continues an observable sequence that is terminated by an exception with the next observable sequence.
     def rescue_error(other = nil, &action)
       return Observable.rescue_error(self, other) if other && !block_given?
-      raise ArgumentError.new 'Invalid arguments' if other.nil? && !block_given?
+      raise ArgumentError.new 'rescue_error requires exactly one of other and action' unless !!other ^ block_given?
 
       AnonymousObservable.new do |observer|
         subscription = SerialSubscription.new

--- a/lib/rx/operators/multiple.rb
+++ b/lib/rx/operators/multiple.rb
@@ -71,7 +71,7 @@ module Rx
     # Continues an observable sequence that is terminated by an exception of the specified type with the observable sequence produced by the handler or
     # continues an observable sequence that is terminated by an exception with the next observable sequence.
     def rescue_error(other = nil, &action)
-      return Observable.rescue_error(other) if other && !block_given?
+      return Observable.rescue_error(self, other) if other && !block_given?
       raise ArgumentError.new 'Invalid arguments' if other.nil? && !block_given?
 
       AnonymousObservable.new do |observer|

--- a/test/rx/operators/test_on_error_resume_next.rb
+++ b/test/rx/operators/test_on_error_resume_next.rb
@@ -1,121 +1,94 @@
 require 'test_helper'
 
 class TestOperatorOnErrorResumeNext < Minitest::Test
-  include Rx::AsyncTesting
-  include Rx::ReactiveTest
-
-  def setup
-    @scheduler = Rx::TestScheduler.new
-    @observer = @scheduler.create_observer
-    @err = RuntimeError.new
-    @left_completing = @scheduler.create_cold_observable(
-      on_next(100, 1),
-      on_completed(200)
-    )
-    @left_erroring = @scheduler.create_cold_observable(
-      on_next(100, 1),
-      on_error(200, @err)
-    )
-    @right_completing = @scheduler.create_cold_observable(
-      on_next(100, 2),
-      on_completed(200)
-    )
-    @right_erroring = @scheduler.create_cold_observable(
-      on_next(100, 2),
-      on_error(200, @err)
-    )
-  end
+  include Rx::MarbleTesting
 
   def test_resumes_next_on_left_error
-    res = @scheduler.configure do
-      @left_erroring.on_error_resume_next(@right_completing)
+    left       = cold('  -1#')
+    right      = cold('    -2|')
+    expected   = msgs('---1-2|')
+    left_subs  = subs('  ^ !')
+    right_subs = subs('    ^ !')
+
+    actual = scheduler.configure do
+      left.on_error_resume_next(right)
     end
 
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_next(SUBSCRIBED + 300, 2),
-      on_completed(SUBSCRIBED + 400)
-    ]
-    assert_messages expected, res.messages
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
   end
 
   def test_completes_on_right_error
-    res = @scheduler.configure do
-      @left_completing.on_error_resume_next(@right_erroring)
+    left       = cold('  -1|')
+    right      = cold('    -2#')
+    expected   = msgs('---1-2|')
+    left_subs  = subs('  ^ !')
+    right_subs = subs('    ^ !')
+
+    actual = scheduler.configure do
+      left.on_error_resume_next(right)
     end
 
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_next(SUBSCRIBED + 300, 2),
-      on_completed(SUBSCRIBED + 400)
-    ]
-    assert_messages expected, res.messages
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
   end
 
   def test_resumes_next_continues_on_complete
-    res = @scheduler.configure do
-      @left_completing.on_error_resume_next(@right_completing)
+    left       = cold('  -1|')
+    right      = cold('    -2|')
+    expected   = msgs('---1-2|')
+    left_subs  = subs('  ^ !')
+    right_subs = subs('    ^ !')
+
+    actual = scheduler.configure do
+      left.on_error_resume_next(right)
     end
 
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_next(SUBSCRIBED + 300, 2),
-      on_completed(SUBSCRIBED + 400)
-    ]
-    assert_messages expected, res.messages
-  end
-
-  def test_subscribes_right_late
-    @scheduler.configure do
-      @left_completing.on_error_resume_next(@right_completing)
-    end
-
-    expected = [
-      subscribe(SUBSCRIBED, SUBSCRIBED + 200)
-    ]
-    assert_subscriptions expected, @left_completing.subscriptions
-    expected = [
-      subscribe(SUBSCRIBED + 200, SUBSCRIBED + 400)
-    ]
-    assert_subscriptions expected, @right_completing.subscriptions
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
   end
 
   def test_right_cannot_be_nil
+    left = cold('  -1|')
     assert_raises(ArgumentError) do
-      @left_completing.on_error_resume_next(nil)
+      left.on_error_resume_next(nil)
     end
   end
 
   def test_accepts_enumerator
+    left       = cold('  -1#')
+    right      = cold('    -2|')
+    expected   = msgs('---1-2|')
+    left_subs  = subs('  ^ !')
+    right_subs = subs('    ^ !')
+
     enum = Enumerator.new do |y|
-      y << @left_erroring
-      y << @right_completing
+      y << left
+      y << right
     end
 
-    res = @scheduler.configure do
+    actual = scheduler.configure do
       Rx::Observable.on_error_resume_next(enum)
     end
 
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_next(SUBSCRIBED + 300, 2),
-      on_completed(SUBSCRIBED + 400)
-    ]
-    assert_messages expected, res.messages
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
   end
 
   def test_erroring_enumerator
+    expected = msgs('--#')
     enum = Enumerator.new do |y|
-      raise @err
+      raise error
     end
 
-    res = @scheduler.configure do
+    actual = scheduler.configure do
       Rx::Observable.on_error_resume_next(enum)
     end
 
-    expected = [
-      on_error(SUBSCRIBED, @err)
-    ]
-    assert_messages expected, res.messages
+    assert_msgs expected, actual
   end
 end

--- a/test/rx/operators/test_on_error_resume_next.rb
+++ b/test/rx/operators/test_on_error_resume_next.rb
@@ -1,0 +1,121 @@
+require 'test_helper'
+
+class TestOperatorOnErrorResumeNext < Minitest::Test
+  include Rx::AsyncTesting
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+    @observer = @scheduler.create_observer
+    @err = RuntimeError.new
+    @left_completing = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_completed(200)
+    )
+    @left_erroring = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_error(200, @err)
+    )
+    @right_completing = @scheduler.create_cold_observable(
+      on_next(100, 2),
+      on_completed(200)
+    )
+    @right_erroring = @scheduler.create_cold_observable(
+      on_next(100, 2),
+      on_error(200, @err)
+    )
+  end
+
+  def test_resumes_next_on_left_error
+    res = @scheduler.configure do
+      @left_erroring.on_error_resume_next(@right_completing)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_next(SUBSCRIBED + 300, 2),
+      on_completed(SUBSCRIBED + 400)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_completes_on_right_error
+    res = @scheduler.configure do
+      @left_completing.on_error_resume_next(@right_erroring)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_next(SUBSCRIBED + 300, 2),
+      on_completed(SUBSCRIBED + 400)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_resumes_next_continues_on_complete
+    res = @scheduler.configure do
+      @left_completing.on_error_resume_next(@right_completing)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_next(SUBSCRIBED + 300, 2),
+      on_completed(SUBSCRIBED + 400)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_subscribes_right_late
+    @scheduler.configure do
+      @left_completing.on_error_resume_next(@right_completing)
+    end
+
+    expected = [
+      subscribe(SUBSCRIBED, SUBSCRIBED + 200)
+    ]
+    assert_subscriptions expected, @left_completing.subscriptions
+    expected = [
+      subscribe(SUBSCRIBED + 200, SUBSCRIBED + 400)
+    ]
+    assert_subscriptions expected, @right_completing.subscriptions
+  end
+
+  def test_right_cannot_be_nil
+    assert_raises(ArgumentError) do
+      @left_completing.on_error_resume_next(nil)
+    end
+  end
+
+  def test_accepts_enumerator
+    enum = Enumerator.new do |y|
+      y << @left_erroring
+      y << @right_completing
+    end
+
+    res = @scheduler.configure do
+      Rx::Observable.on_error_resume_next(enum)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_next(SUBSCRIBED + 300, 2),
+      on_completed(SUBSCRIBED + 400)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_erroring_enumerator
+    enum = Enumerator.new do |y|
+      raise @err
+    end
+
+    res = @scheduler.configure do
+      Rx::Observable.on_error_resume_next(enum)
+    end
+
+    expected = [
+      on_error(SUBSCRIBED, @err)
+    ]
+    assert_messages expected, res.messages
+  end
+end

--- a/test/rx/operators/test_rescue_error.rb
+++ b/test/rx/operators/test_rescue_error.rb
@@ -1,6 +1,151 @@
 require 'test_helper'
 
 class TestOperatorRescueError < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_erroring_left
+    left       = cold('  -1#')
+    right      = cold('    -2|')
+    expected   = msgs('---1-2|')
+    left_subs  = subs('  ^ !')
+    right_subs = subs('    ^ !')
+    actual = scheduler.configure { left.rescue_error(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_erroring_left_with_block
+    left       = cold('  -1#')
+    right      = cold('    -2|')
+    expected   = msgs('---1-2|')
+    left_subs  = subs('  ^ !')
+    right_subs = subs('    ^ !')
+
+    actual = scheduler.configure do
+      left.rescue_error do |err|
+        assert_equal error, err
+        right
+      end
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_with_erroring_block
+    block_error = RuntimeError.new
+    left       = cold('  -1#')
+    expected   = msgs('---1#', error: block_error)
+    left_subs  = subs('  ^ !')
+
+    actual = scheduler.configure do
+      left.rescue_error do |err|
+        raise block_error
+      end
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_left_completes_so_right_is_not_consulted
+    left       = cold('  -1|')
+    right      = cold('    -2|')
+    expected   = msgs('---1|')
+    left_subs  = subs('  ^ !')
+    right_subs = subs('     ')
+    actual = scheduler.configure { left.rescue_error(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_rescue_error_without_error
+    left       = cold('  -1|')
+    right      = cold('    -2#')
+    expected   = msgs('---1|')
+    left_subs  = subs('  ^ !')
+    right_subs = subs('     ')
+    actual = scheduler.configure { left.rescue_error(right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_empty_source_completes
+    actual = scheduler.configure do
+      Rx::Observable.rescue_error()
+    end
+    assert_msgs [on_completed(200)], actual
+  end
+
+  def test_observable_rescue_error
+    left       = cold('  -1#')
+    right      = cold('    -2|')
+    expected   = msgs('---1-2|')
+    left_subs  = subs('  ^ !')
+    right_subs = subs('    ^ !')
+
+    actual = scheduler.configure { Rx::Observable.rescue_error(left, right) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_accepts_enumerator
+    left       = cold('  -1#')
+    right      = cold('    -2|')
+    expected   = msgs('---1-2|')
+    left_subs  = subs('  ^ !')
+    right_subs = subs('    ^ !')
+
+    enum = Enumerator.new do |y|
+      y << left
+      y << right
+    end
+
+    actual = scheduler.configure { Rx::Observable.rescue_error(enum) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_erroring_enumerator
+    enum = Enumerator.new do |y|
+      raise error
+    end
+
+    actual = scheduler.configure do
+      Rx::Observable.rescue_error(enum)
+    end
+
+    expected = msgs('--#')
+    assert_msgs expected, actual
+  end
+
+  def test_disposing_stops_enumeration
+    erroring      = cold('-#')
+    erroring_subs = subs('  ^(!^)!')
+    enum = Enumerator.new do |y|
+      y << erroring while true
+    end
+
+    scheduler.configure(disposed: 400) do
+      Rx::Observable.rescue_error(enum)
+    end
+
+    assert_subs erroring_subs, erroring
+  end
+end
+
+class TestRescueErrorConcurrency < Minitest::Test
   include Rx::AsyncTesting
   include Rx::ReactiveTest
 
@@ -8,193 +153,7 @@ class TestOperatorRescueError < Minitest::Test
     @scheduler = Rx::TestScheduler.new
     @observer = @scheduler.create_observer
     @err = RuntimeError.new
-    @left_completing = @scheduler.create_cold_observable(
-      on_next(100, 1),
-      on_completed(200)
-    )
-    @left_erroring = @scheduler.create_cold_observable(
-      on_next(100, 1),
-      on_error(200, @err)
-    )
-    @right_completing = @scheduler.create_cold_observable(
-      on_next(100, 2),
-      on_completed(200)
-    )
-    @right_erroring = @scheduler.create_cold_observable(
-      on_next(100, 2),
-      on_error(200, @err)
-    )
   end
-
-  def test_erroring_left
-    res = @scheduler.configure do
-      @left_erroring.rescue_error(@right_completing)
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_next(SUBSCRIBED + 300, 2),
-      on_completed(SUBSCRIBED + 400)
-    ]
-    assert_messages expected, res.messages
-  end
-
-  def test_erroring_left_with_block
-    res = @scheduler.configure do
-      @left_erroring.rescue_error do |err|
-        @scheduler.create_cold_observable(
-          on_next(100, err),
-          on_completed(200)
-        )
-      end
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_next(SUBSCRIBED + 300, @err),
-      on_completed(SUBSCRIBED + 400)
-    ]
-    assert_messages expected, res.messages
-  end
-
-  def test_with_erroring_block
-    res = @scheduler.configure do
-      @left_erroring.rescue_error do |err|
-        raise @err
-      end
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_error(SUBSCRIBED + 200, @err)
-    ]
-    assert_messages expected, res.messages
-  end
-
-  def test_no_error
-    res = @scheduler.configure do
-      @left_completing.rescue_error(@right_completing)
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_completed(SUBSCRIBED + 200)
-    ]
-    assert_messages expected, res.messages
-  end
-
-  def test_unsubscribes_from_erroring_left
-    @scheduler.configure do
-      @left_erroring.rescue_error(@right_completing)
-    end
-
-    assert_subscriptions [subscribe(200, 400)], @left_erroring.subscriptions
-    assert_subscriptions [subscribe(400, 600)], @right_completing.subscriptions
-  end
-
-  def test_rescue_error_without_error
-    res = @scheduler.configure do
-      @left_completing.rescue_error(@right_erroring)
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_completed(SUBSCRIBED + 200)
-    ]
-    assert_messages expected, res.messages
-  end
-
-  def test_unsubscribes_from_completing_left
-    @scheduler.configure do
-      @left_completing.rescue_error(@right_erroring)
-    end
-
-    assert_subscriptions [subscribe(200, 400)], @left_completing.subscriptions
-    assert_subscriptions [], @right_erroring.subscriptions
-  end
-
-  def test_empty_source_completes
-    res = @scheduler.configure do
-      Rx::Observable.rescue_error()
-    end
-    assert_messages [on_completed(200)], res.messages
-  end
-
-  def test_observable_rescue_error
-    res = @scheduler.configure do
-      Rx::Observable.rescue_error(@left_erroring, @right_completing)
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_next(SUBSCRIBED + 300, 2),
-      on_completed(SUBSCRIBED + 400)
-    ]
-    assert_messages expected, res.messages
-  end
-
-  def test_accepts_enumerator
-    enum = Enumerator.new do |y|
-      y << @left_erroring
-      y << @right_completing
-    end
-
-    res = @scheduler.configure do
-      Rx::Observable.rescue_error(enum)
-    end
-
-    expected = [
-      on_next(SUBSCRIBED + 100, 1),
-      on_next(SUBSCRIBED + 300, 2),
-      on_completed(SUBSCRIBED + 400)
-    ]
-    assert_messages expected, res.messages
-  end
-
-  def test_erroring_enumerator
-    enum = Enumerator.new do |y|
-      raise @err
-    end
-
-    res = @scheduler.configure do
-      Rx::Observable.rescue_error(enum)
-    end
-
-    expected = [
-      on_error(SUBSCRIBED, @err)
-    ]
-    assert_messages expected, res.messages
-  end
-
-  def test_disposing_stops_enumeration
-    erroring = @scheduler.create_cold_observable(
-      on_error(100, @err)
-    )
-    enum = Enumerator.new do |y|
-      y << erroring while true
-    end
-
-    @scheduler.configure(disposed: 400) do
-      Rx::Observable.rescue_error(enum)
-    end
-
-    expected = [
-      subscribe(SUBSCRIBED, SUBSCRIBED + 100),
-      subscribe(SUBSCRIBED + 100, SUBSCRIBED + 200)
-    ]
-    assert_subscriptions expected, erroring.subscriptions
-  end
-
-    def async_observable(*messages)
-      Rx::Observable.create do |observer|
-        Thread.new do
-          sleep 0.001
-          messages.each do |m|
-            m.value.accept observer
-          end
-        end
-      end
-    end
 
   def test_observable_rescue_error_concurrent
     sentinel_called = false

--- a/test/rx/operators/test_rescue_error.rb
+++ b/test/rx/operators/test_rescue_error.rb
@@ -1,0 +1,225 @@
+require 'test_helper'
+
+class TestOperatorRescueError < Minitest::Test
+  include Rx::AsyncTesting
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+    @observer = @scheduler.create_observer
+    @err = RuntimeError.new
+    @left_completing = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_completed(200)
+    )
+    @left_erroring = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_error(200, @err)
+    )
+    @right_completing = @scheduler.create_cold_observable(
+      on_next(100, 2),
+      on_completed(200)
+    )
+    @right_erroring = @scheduler.create_cold_observable(
+      on_next(100, 2),
+      on_error(200, @err)
+    )
+  end
+
+  def test_erroring_left
+    res = @scheduler.configure do
+      @left_erroring.rescue_error(@right_completing)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_next(SUBSCRIBED + 300, 2),
+      on_completed(SUBSCRIBED + 400)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_erroring_left_with_block
+    res = @scheduler.configure do
+      @left_erroring.rescue_error do |err|
+        @scheduler.create_cold_observable(
+          on_next(100, err),
+          on_completed(200)
+        )
+      end
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_next(SUBSCRIBED + 300, @err),
+      on_completed(SUBSCRIBED + 400)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_with_erroring_block
+    res = @scheduler.configure do
+      @left_erroring.rescue_error do |err|
+        raise @err
+      end
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_error(SUBSCRIBED + 200, @err)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_no_error
+    res = @scheduler.configure do
+      @left_completing.rescue_error(@right_completing)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_completed(SUBSCRIBED + 200)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_unsubscribes_from_erroring_left
+    @scheduler.configure do
+      @left_erroring.rescue_error(@right_completing)
+    end
+
+    assert_subscriptions [subscribe(200, 400)], @left_erroring.subscriptions
+    assert_subscriptions [subscribe(400, 600)], @right_completing.subscriptions
+  end
+
+  def test_rescue_error_without_error
+    res = @scheduler.configure do
+      @left_completing.rescue_error(@right_erroring)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_completed(SUBSCRIBED + 200)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_unsubscribes_from_completing_left
+    @scheduler.configure do
+      @left_completing.rescue_error(@right_erroring)
+    end
+
+    assert_subscriptions [subscribe(200, 400)], @left_completing.subscriptions
+    assert_subscriptions [], @right_erroring.subscriptions
+  end
+
+  def test_empty_source_completes
+    res = @scheduler.configure do
+      Rx::Observable.rescue_error()
+    end
+    assert_messages [on_completed(200)], res.messages
+  end
+
+  def test_observable_rescue_error
+    res = @scheduler.configure do
+      Rx::Observable.rescue_error(@left_erroring, @right_completing)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_next(SUBSCRIBED + 300, 2),
+      on_completed(SUBSCRIBED + 400)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_accepts_enumerator
+    enum = Enumerator.new do |y|
+      y << @left_erroring
+      y << @right_completing
+    end
+
+    res = @scheduler.configure do
+      Rx::Observable.rescue_error(enum)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_next(SUBSCRIBED + 300, 2),
+      on_completed(SUBSCRIBED + 400)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_erroring_enumerator
+    enum = Enumerator.new do |y|
+      raise @err
+    end
+
+    res = @scheduler.configure do
+      Rx::Observable.rescue_error(enum)
+    end
+
+    expected = [
+      on_error(SUBSCRIBED, @err)
+    ]
+    assert_messages expected, res.messages
+  end
+
+  def test_disposing_stops_enumeration
+    erroring = @scheduler.create_cold_observable(
+      on_error(100, @err)
+    )
+    enum = Enumerator.new do |y|
+      y << erroring while true
+    end
+
+    @scheduler.configure(disposed: 400) do
+      Rx::Observable.rescue_error(enum)
+    end
+
+    expected = [
+      subscribe(SUBSCRIBED, SUBSCRIBED + 100),
+      subscribe(SUBSCRIBED + 100, SUBSCRIBED + 200)
+    ]
+    assert_subscriptions expected, erroring.subscriptions
+  end
+
+    def async_observable(*messages)
+      Rx::Observable.create do |observer|
+        Thread.new do
+          sleep 0.001
+          messages.each do |m|
+            m.value.accept observer
+          end
+        end
+      end
+    end
+
+  def test_observable_rescue_error_concurrent
+    sentinel_called = false
+    observables = [
+      async_observable(
+        on_next(0, 1),
+        on_error(0, @err)
+      ),
+      async_observable(
+        *([on_next(0, 2)] * 3),
+        on_completed(0)
+      ),
+      async_observable(
+        on_error(0, @err)
+      ).do { sentinel_called = true }
+    ]
+    Rx::Observable.rescue_error(*observables)
+      .subscribe(@observer)
+    await_array_length(@observer.messages, 5)
+    assert_equal false, sentinel_called
+    expected = [
+      on_next(0, 1),
+      *[on_next(0, 2)] * 3,
+      on_completed(0)
+    ]
+    assert_messages expected, @observer.messages
+  end
+end

--- a/test/rx/operators/test_rescue_error.rb
+++ b/test/rx/operators/test_rescue_error.rb
@@ -51,6 +51,14 @@ class TestOperatorRescueError < Minitest::Test
     assert_subs left_subs, left
   end
 
+  def test_resfuse_right_and_block
+    left       = cold('  -#')
+    right      = cold('   -1|')
+    assert_raises(ArgumentError) do
+      left.rescue_error(right) {|_| Rx::Observable.empty() }
+    end
+  end
+
   def test_left_completes_so_right_is_not_consulted
     left       = cold('  -1|')
     right      = cold('    -2|')

--- a/test/rx/operators/test_retry.rb
+++ b/test/rx/operators/test_retry.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class TestOperatorRetry < Minitest::Test
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+    @observer = @scheduler.create_observer
+    @err = RuntimeError.new
+    @left_completing = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_completed(200)
+    )
+    @left_erroring = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_error(200, @err)
+    )
+  end
+
+  def test_retries_when_left_erroring
+    res = @scheduler.configure do
+      @left_erroring.retry(2)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_next(SUBSCRIBED + 300, 1),
+      on_error(SUBSCRIBED + 400, @err)
+    ]
+    assert_messages expected, res.messages
+  end
+  
+  def test_does_not_retry_without_error
+    res = @scheduler.configure do
+      @left_completing.retry(2)
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_completed(SUBSCRIBED + 200)
+    ]
+    assert_messages expected, res.messages
+  end
+  
+  def retry_infinitely
+    subscription = Rx::Observable.raise_error(@err)
+      .retry_infinitely
+      .subscribe_on(Rx::DefaultScheduler.instance)
+      .subscribe(@observer)
+    await_array_minimum_length(@observer.messages, 10)
+    subscription.unsubscribe
+    expected = ([
+      on_error(SUBSCRIBED, 1)
+    ] * 10).flatten
+    assert_messages expected, @observer.messages.take(10)
+  end
+  
+  def retry_infinitely_without_error
+    res = @scheduler.configure do
+      @left_completing.retry_infinitely
+    end
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_completed(SUBSCRIBED + 200)
+    ]
+    assert_messages expected, res.messages
+  end
+end

--- a/test/rx/operators/test_retry_infinitely.rb
+++ b/test/rx/operators/test_retry_infinitely.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class TestOperatorRetryInfinitely < Minitest::Test
+  include Rx::ReactiveTest
+
+  def setup
+    @scheduler = Rx::TestScheduler.new
+    @observer = @scheduler.create_observer
+    @err = RuntimeError.new
+  end
+
+  def retry_infinitely
+    subscription = Rx::Observable.raise_error(@err)
+      .retry_infinitely
+      .subscribe_on(Rx::DefaultScheduler.instance)
+      .subscribe(@observer)
+    await_array_minimum_length(@observer.messages, 10)
+    subscription.unsubscribe
+    expected = ([
+      on_error(SUBSCRIBED, 1)
+    ] * 10).flatten
+    assert_messages expected, @observer.messages.take(10)
+  end
+
+  def retry_infinitely_without_error
+    left = @scheduler.create_cold_observable(
+      on_next(100, 1),
+      on_completed(200)
+    )
+
+    actual = @scheduler.configure { left.retry_infinitely }
+
+    expected = [
+      on_next(SUBSCRIBED + 100, 1),
+      on_completed(SUBSCRIBED + 200)
+    ]
+    assert_messages expected, actual.messages
+  end
+end


### PR DESCRIPTION
Marble-style tests for `.rescue_error`, `.retry`, `.retry_infinitely`, `.on_error_resume_next`.

Changelog:
- actually try left observable (i.e. self) before trying alternate observable.
- clarify that instance `.rescue_error` won't accept both alternate observable and block.