### PR TITLE
Travis does not need the codecov token

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-if ENV['CODECOV_TOKEN']
+if ENV['CI'] = 'true'
   require 'simplecov'
   require 'codecov'
 


### PR DESCRIPTION
According to Codecov docs, you don't need to supply the token when on Travis CI.