### PR TITLE
Marble messages with digits are converted to numbers

### DIFF
--- a/lib/rx/testing/marble_testing.rb
+++ b/lib/rx/testing/marble_testing.rb
@@ -28,7 +28,8 @@ module Rx
         when '#'
           on_error(time, values[:error] || error)
         else
-          on_next(time, values[event.to_sym] || event)
+          v = values[event.to_sym] || (Integer(event) rescue event)
+          on_next(time, v)
         end
         time += increment
         message

--- a/test/rx/linq/observable/test_for.rb
+++ b/test/rx/linq/observable/test_for.rb
@@ -5,7 +5,7 @@ class TestObservableFor < Minitest::Test
 
   def test_array
     actual = scheduler.configure do
-      Rx::Observable.for(%w[1 2 3].map {|n| Rx::Observable.of(n) })
+      Rx::Observable.for([1, 2, 3].map {|n| Rx::Observable.of(n) })
     end
 
     assert_msgs msgs('--(123|)'), actual
@@ -19,7 +19,7 @@ class TestObservableFor < Minitest::Test
 
   def test_with_transform
     actual = scheduler.configure do
-      Rx::Observable.for(%w[1 2 3]) {|n| Rx::Observable.of(n) }
+      Rx::Observable.for([1, 2, 3]) {|n| Rx::Observable.of(n) }
     end
 
     assert_msgs msgs('--(123|)'), actual

--- a/test/rx/operators/test_combine_latest.rb
+++ b/test/rx/operators/test_combine_latest.rb
@@ -11,7 +11,7 @@ class TestCombineLatest < Minitest::Test
     right_subs   = subs('--^-----!')
 
     actual = scheduler.configure do
-      left.combine_latest(right) { |*values| values.map(&:to_i).inject(0, :+).to_s }
+      left.combine_latest(right) { |*values| values.inject(0, :+) }
     end
 
     assert_msgs expected, actual
@@ -27,7 +27,7 @@ class TestObservableCombineLatest < Minitest::Test
     a        = cold('  -1----4|')
     b        = cold('  --2--5|')
     c        = cold('  ---36|')
-    expected = msgs('-----abcd|', a: %w[1 2 3], b: %w[1 2 6], c: %w[1 5 6], d: %w[4 5 6])
+    expected = msgs('-----abcd|', a: [1, 2, 3], b: [1, 2, 6], c: [1, 5, 6], d: [4, 5, 6])
     a_subs   = subs('--^------!')
     b_subs   = subs('--^-----!')
     c_subs   = subs('--^----!')
@@ -45,7 +45,7 @@ class TestObservableCombineLatest < Minitest::Test
   def test_emit_only_latest_from_each_source
     a        = cold('  -123--|')
     b        = cold('  ----4-|')
-    expected = msgs('------a-|', a: %w[3 4])
+    expected = msgs('------a-|', a: [3, 4])
     a_subs   = subs('--^-----!')
     b_subs   = subs('--^-----!')
 
@@ -62,7 +62,7 @@ class TestObservableCombineLatest < Minitest::Test
     a        = cold('  -1-----5|')
     b        = cold('  --2--4|')
     c        = cold('  ---3|')
-    expected = msgs('-----a-b-c|', a: %w[1 2 3], b: %w[1 4 3], c: %w[5 4 3])
+    expected = msgs('-----a-b-c|', a: [1, 2, 3], b: [1, 4, 3], c: [5, 4, 3])
     a_subs   = subs('--^-------!')
     b_subs   = subs('--^-----!')
     c_subs   = subs('--^---!')
@@ -130,7 +130,7 @@ class TestObservableCombineLatest < Minitest::Test
     b_subs   = subs('--^-----!')
 
     actual = scheduler.configure do
-      Rx::Observable.combine_latest(a, b) { |*values| values.map(&:to_i).inject(0, :+).to_s }
+      Rx::Observable.combine_latest(a, b) { |*values| values.inject(0, :+) }
     end
 
     assert_msgs expected, actual

--- a/test/rx/operators/test_start_with.rb
+++ b/test/rx/operators/test_start_with.rb
@@ -8,7 +8,7 @@ class TestOperatorStartWith < Minitest::Test
     expected    = msgs('--(1-)2|')
     source_subs = subs('  ^ !')
 
-    actual = scheduler.configure { source.start_with('1') }
+    actual = scheduler.configure { source.start_with(1) }
 
     assert_msgs expected, actual
     assert_subs source_subs, source
@@ -19,7 +19,7 @@ class TestOperatorStartWith < Minitest::Test
     expected    = msgs('--(1-)2#')
     source_subs = subs('  ^ !')
 
-    actual = scheduler.configure { source.start_with('1') }
+    actual = scheduler.configure { source.start_with(1) }
 
     assert_msgs expected, actual
     assert_subs source_subs, source

--- a/test/rx/operators/test_zip.rb
+++ b/test/rx/operators/test_zip.rb
@@ -6,7 +6,7 @@ class TestOperatorZip < Minitest::Test
   def test_emit_pairs_in_arrival_order
     a        = cold('  -12-3-|')
     b        = cold('  ---4-5|')
-    expected = msgs('-----a-b|', a: %w[1 4], b: %w[2 5])
+    expected = msgs('-----a-b|', a: [1, 4], b: [2, 5])
     a_subs   = subs('--^-----!')
     b_subs   = subs('--^-----!')
 
@@ -25,7 +25,7 @@ class TestObservableZip < Minitest::Test
     a        = cold('  -1----4|')
     b        = cold('  --2--5-|')
     c        = cold('  ---36--|')
-    expected = msgs('-----a--b|', a: %w[1 2 3], b: %w[4 5 6])
+    expected = msgs('-----a--b|', a: [1, 2, 3], b: [4, 5, 6])
     a_subs   = subs('--^------!')
     b_subs   = subs('--^------!')
     c_subs   = subs('--^------!')
@@ -43,7 +43,7 @@ class TestObservableZip < Minitest::Test
   def test_emit_pairs_in_arrival_order
     a        = cold('  -12-3-|')
     b        = cold('  ---4-5|')
-    expected = msgs('-----a-b|', a: %w[1 4], b: %w[2 5])
+    expected = msgs('-----a-b|', a: [1, 4], b: [2, 5])
     a_subs   = subs('--^-----!')
     b_subs   = subs('--^-----!')
 
@@ -59,7 +59,7 @@ class TestObservableZip < Minitest::Test
   def test_complete_when_first_completes_no_buffers
     a        = cold('  -1-|')
     b        = cold('  --2-|')
-    expected = msgs('----a|', a: %w[1 2])
+    expected = msgs('----a|', a: [1, 2])
     a_subs   = subs('--^--!')
     b_subs   = subs('--^--!')
 
@@ -75,7 +75,7 @@ class TestObservableZip < Minitest::Test
   def test_complete_when_first_complete_and_queue_empty
     a        = cold('  -12|')
     b        = cold('  ---34--|')
-    expected = msgs('-----a(b|)', a: %w[1 3], b: %w[2 4])
+    expected = msgs('-----a(b|)', a: [1, 3], b: [2, 4])
     a_subs   = subs('--^--!')
     b_subs   = subs('--^---!')
 
@@ -91,7 +91,7 @@ class TestObservableZip < Minitest::Test
   def test_propagate_error_from_when_no_buffer
     a        = cold('  -1---|')
     b        = cold('  --2#')
-    expected = msgs('----a#', a: %w[1 2])
+    expected = msgs('----a#', a: [1, 2])
     a_subs   = subs('--^--!')
     b_subs   = subs('--^--!')
 
@@ -107,7 +107,7 @@ class TestObservableZip < Minitest::Test
   def test_propagate_error_from_when_when_buffered
     a        = cold('  -1-2--|')
     b        = cold('  --3-#')
-    expected = msgs('----a-#', a: %w[1 3])
+    expected = msgs('----a-#', a: [1, 3])
     a_subs   = subs('--^---!')
     b_subs   = subs('--^---!')
 
@@ -128,7 +128,7 @@ class TestObservableZip < Minitest::Test
     b_subs   = subs('--^--!')
 
     actual = scheduler.configure do
-      Rx::Observable.zip(a, b) { |*values| values.map(&:to_i).inject(0, :+).to_s }
+      Rx::Observable.zip(a, b) { |*values| values.inject(0, :+) }
     end
 
     assert_msgs expected, actual


### PR DESCRIPTION
When writing tests for `.sum` and `.average` I could not use marble-style tests because they only generate strings. This PR changes `.msgs` so that it converts digits to integers. This affects a few existing tests which the PR cleans up. Once merged, operators that assume numerical items can have marble-style tests too.
  