### PR TITLE
Proc passed via .msgs values is interpreted as a predicate

### DIFF
--- a/lib/rx/testing/marble_testing.rb
+++ b/lib/rx/testing/marble_testing.rb
@@ -26,10 +26,19 @@ module Rx
         when '|'
           on_completed(time)
         when '#'
-          on_error(time, values[:error] || error)
+          v = values[:error] || error
+          if v.is_a? Proc
+            on_error_predicate(time, &v)
+          else
+            on_error(time, v)
+          end
         else
           v = values[event.to_sym] || (Integer(event) rescue event)
-          on_next(time, v)
+          if v.is_a? Proc
+            on_next_predicate(time, &v)
+          else
+            on_next(time, v)
+          end
         end
         time += increment
         message


### PR DESCRIPTION
In order to be able to deeply compare exceptions in marble-style tests, we need to use `on_error_predicate`. This PR introduces the convention that a proc passed via custom values will be interpreted as `on_(next|error)_predicate` rather than `on_next` or `on_error`. See e.g. operator `.average` tests for example.