### PR TITLE
Tests for operators .average, .count, .reduce, .scan, .sum, .to_a, .to_h

### DIFF
--- a/lib/rx/operators/aggregates.rb
+++ b/lib/rx/operators/aggregates.rb
@@ -108,7 +108,15 @@ module Rx
     # @return [Rx::Observable]
     def average(&block)
       return map(&block).average if block_given?
-      scan({:sum => 0, :count => 0}) {|prev, current| {:sum => prev[:sum] + current, :count => prev[:count] + 1 }}.
+      scan({:sum => 0, :count => 0}) do |acc, n|
+        begin
+          acc[:sum] += n
+          acc[:count] += 1
+        rescue TypeError => e
+          raise TypeError.new("average expected #{n} to be numerical (#{e.message})")
+        end
+        acc
+      end.
       final.
       map {|x|
         raise 'Sequence contains no elements' if x[:count] == 0
@@ -512,7 +520,13 @@ module Rx
     # source sequence.
     def sum(&block)
       return map(&block).sum if block_given?
-      reduce(0) {|acc, x| acc + x}
+      reduce(0) do |acc, n|
+        begin
+          acc + n
+        rescue TypeError => e
+          raise TypeError.new("sum expected #{n} to be numerical (#{e.message})")
+        end
+      end
     end
 
     # Creates an array from an observable sequence.

--- a/lib/rx/operators/aggregates.rb
+++ b/lib/rx/operators/aggregates.rb
@@ -559,7 +559,7 @@ module Rx
       end
 
       def value_selector(&value_selector_block)
-        @on_error_block = value_selector_block
+        @value_selector_block = value_selector_block
       end
     end
 

--- a/lib/rx/operators/single.rb
+++ b/lib/rx/operators/single.rb
@@ -230,7 +230,7 @@ module Rx
               end
             rescue => err
               observer.on_error err
-              break
+              next
             end
 
             observer.on_next accumulation

--- a/test/rx/operators/test_average.rb
+++ b/test/rx/operators/test_average.rb
@@ -1,0 +1,79 @@
+require 'test_helper'
+
+class TestOperatorAverage < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_calculates_average_of_emitted_values
+    source       = cold('  -2424|')
+    expected     = msgs('-------(3|)')
+    source_subs  = subs('  ^    !')
+
+    actual = scheduler.configure { source.average }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_maps_with_block
+    source       = cold('  -2424|')
+    expected     = msgs('-------(4|)')
+    source_subs  = subs('  ^    !')
+
+    actual = scheduler.configure do
+      source.average { |n| n + 1 }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block
+    source       = cold('  -2424|')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.average { |n| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source       = cold('  -2#')
+    expected     = msgs('----#')
+    source_subs  = subs('  ^ !')
+
+    actual = scheduler.configure { source.average }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_fails_on_non_numerical_values
+    my_err = ->(err) { err.is_a?(TypeError) && err.message.match(/blah.*numerical/) }
+
+    source       = cold('  -a', a: 'blah')
+    expected     = msgs('---#', error: my_err)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.average }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_fails_on_empty_sequence
+    my_err = ->(err) { err.is_a?(RuntimeError) && err.message.include?('no elements') }
+
+    source       = cold('  -|')
+    expected     = msgs('---#', error: my_err)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.average }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_count.rb
+++ b/test/rx/operators/test_count.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class TestOperatorCount < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_counts_emitted_values
+    source       = cold('  -abc|')
+    expected     = msgs('------(3|)')
+    source_subs  = subs('  ^   !')
+
+    actual = scheduler.configure { source.count }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_counts_only_values_selected_by_block
+    source       = cold('  -abc|')
+    expected     = msgs('------(2|)')
+    source_subs  = subs('  ^   !')
+
+    actual = scheduler.configure do
+      source.count { |c| c >= 'b' }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source       = cold('  -a#')
+    expected     = msgs('----#')
+    source_subs  = subs('  ^ !')
+
+    actual = scheduler.configure { source.count }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block
+    source       = cold('  -abc|')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.count { |c| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_reduce.rb
+++ b/test/rx/operators/test_reduce.rb
@@ -1,0 +1,143 @@
+require 'test_helper'
+
+class TestOperatorReduce < Minitest::Test
+  include Rx::MarbleTesting
+  
+  class Reducable
+    attr_reader :value
+
+    def initialize(value)
+      @value = value
+    end
+
+    def reduce_me(other)
+      Reducable.new(value + other.value)
+    end
+
+    def ==(other)
+      value == other.value
+    end
+  end
+  
+  def test_symbol_names_reducer_on_emitted_value
+    left       = cold('  -ab|', a: Reducable.new(1), b: Reducable.new(2))
+    expected   = msgs('-----(a|)', a: Reducable.new(3))
+    left_subs  = subs('  ^  !')
+
+    actual = scheduler.configure { left.reduce(:reduce_me) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_seed_reducer_named_by_symbol
+    left       = cold('  -ab|', a: Reducable.new(1), b: Reducable.new(2))
+    expected   = msgs('-----(a|)', a: Reducable.new(4))
+    left_subs  = subs('  ^  !')
+
+    actual = scheduler.configure { left.reduce(Reducable.new(1), :reduce_me) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_reduce_emitted_values_using_block
+    left       = cold('  -12|')
+    expected   = msgs('-----(3|)')
+    left_subs  = subs('  ^  !')
+
+    actual = scheduler.configure do
+      left.reduce { |acc, x| acc + x }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_seed_reducer_using_block
+    left       = cold('  -12|')
+    expected   = msgs('-----(4|)')
+    left_subs  = subs('  ^  !')
+
+    actual = scheduler.configure do
+      left.reduce(1) { |acc, x| acc + x }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_with_error
+    left       = cold('  -12#')
+    expected   = msgs('-----#')
+    left_subs  = subs('  ^  !')
+
+    actual = scheduler.configure do
+      left.reduce { |acc, x| acc + x }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_erroring_block
+    left       = cold('  -12')
+    expected   = msgs('----#')
+    left_subs  = subs('  ^ !')
+
+    actual = scheduler.configure do
+      left.reduce { |acc, x| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_erroring_block_with_seed
+    left       = cold('  -2')
+    expected   = msgs('---#')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      left.reduce(1) { |acc, x| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_emits_error_on_empty_sequence
+    my_err = ->(err) { err.is_a?(RuntimeError) && err.message.include?('no elements') }
+
+    left       = cold('  -|')
+    expected   = msgs('---#', error: my_err)
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      left.reduce { |acc, x| acc + x }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_seed_emitted_even_on_empty_sequence
+    left       = cold('  -|')
+    expected   = msgs('---(1|)')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      left.reduce(1) { |acc, x| acc + x }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_too_many_arguments
+    left       = cold('  -1')
+    assert_raises(ArgumentError) do
+      left.reduce(1, 2) { |_| }
+    end
+  end
+end

--- a/test/rx/operators/test_scan.rb
+++ b/test/rx/operators/test_scan.rb
@@ -1,0 +1,141 @@
+require 'test_helper'
+
+class TestOperatorScan < Minitest::Test
+  include Rx::MarbleTesting
+
+  class Reducable
+    attr_reader :value
+
+    def initialize(value)
+      @value = value
+    end
+
+    def reduce(other)
+      Reducable.new(value + other.value)
+    end
+
+    def ==(other)
+      value == other.value
+    end
+  end
+
+  def test_symbol_names_reducer_on_emitted_value
+    source       = cold('  -ab|', a: Reducable.new(1), b: Reducable.new(2))
+    expected     = msgs('---ab|', a: Reducable.new(1), b: Reducable.new(3))
+    source_subs  = subs('  ^  !')
+
+    actual = scheduler.configure { source.scan(:reduce) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_seed_reducer_named_by_symbol
+    source       = cold('  -ab|', a: Reducable.new(1), b: Reducable.new(2))
+    expected     = msgs('---ab|', a: Reducable.new(2), b: Reducable.new(4))
+    source_subs  = subs('  ^  !')
+
+    actual = scheduler.configure { source.scan(Reducable.new(1), :reduce) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_scan_emitted_values_using_block
+    source       = cold('  -12|')
+    expected     = msgs('---13|')
+    source_subs  = subs('  ^  !')
+
+    actual = scheduler.configure do
+      source.scan { |acc, x| acc + x }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_seed_scan_with_block
+    source       = cold('  -12|')
+    expected     = msgs('---24|')
+    source_subs  = subs('  ^  !')
+
+    actual = scheduler.configure do
+      source.scan(1) { |acc, x| acc + x }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_with_error
+    source       = cold('  -12#')
+    expected     = msgs('---13#')
+    source_subs  = subs('  ^  !')
+
+    actual = scheduler.configure do
+      source.scan { |acc, x| acc + x }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block
+    source       = cold('  -12')
+    expected     = msgs('---1#')
+    source_subs  = subs('  ^ !')
+
+    actual = scheduler.configure do
+      source.scan { |acc, x| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block_with_seed
+    source       = cold('  -2')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.scan(1) { |acc, x| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_empty_observable
+    source       = cold('  -|')
+    expected     = msgs('---|')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.scan { |acc, x| acc + x }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_empty_observable_with_seed
+    source       = cold('  -|')
+    expected     = msgs('---(1|)')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.scan(1) { |acc, x| acc + x }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_argument_error_on_too_many_arguments
+    source = cold('  -1')
+    assert_raises(ArgumentError) do
+      source.scan(1, 2) { |_| }
+    end
+  end
+end

--- a/test/rx/operators/test_sum.rb
+++ b/test/rx/operators/test_sum.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+class TestOperatorSum < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_calculates_sum_of_emitted_values
+    source       = cold('  -123|')
+    expected     = msgs('------(6|)')
+    source_subs  = subs('  ^   !')
+
+    actual = scheduler.configure { source.sum }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_maps_with_block
+    source       = cold('  -123|')
+    expected     = msgs('------(9|)')
+    source_subs  = subs('  ^   !')
+
+    actual = scheduler.configure do
+      source.sum { |n| n + 1 }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block
+    source       = cold('  -2424|')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.sum { |n| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source       = cold('  -2#')
+    expected     = msgs('----#')
+    source_subs  = subs('  ^ !')
+
+    actual = scheduler.configure { source.sum }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_fails_on_non_numerical_input
+    my_err = ->(err) { err.is_a?(TypeError) && err.message.match(/blah.*numerical/) }
+
+    source       = cold('  -a', a: 'blah')
+    expected     = msgs('---#', error: my_err)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.sum }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_zero_on_empty
+    source       = cold('  -|')
+    expected     = msgs('---(0|)')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.sum }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_to_a.rb
+++ b/test/rx/operators/test_to_a.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class TestOperatorToA < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_collects_sequence_into_array_on_complete
+    source      = cold('  -123|')
+    expected    = msgs('------(a|)', a: [1, 2, 3])
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure { source.to_a }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_respects_nil_as_value
+    source      = cold('  -a|', a: nil)
+    expected    = msgs('----(a|)', a: [nil])
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure { source.to_a }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.to_a }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_to_h.rb
+++ b/test/rx/operators/test_to_h.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+class TestOperatorToH < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_collects_sequence_into_hash_on_complete
+    result = {'a' => 'a', 'b' => 'b', 'c' => 'c'}
+    source      = cold('  -abc|')
+    expected    = msgs('------(a|)', a: result)
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure { source.to_h }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_block_selects_hash_key
+    result = {'1' => 1, '2' => 2, '3' => 3}
+    source      = cold('  -123|')
+    expected    = msgs('------(a|)', a: result)
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure do
+      source.to_h do |c|
+        c.key_selector { |k| k.to_s }
+      end
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_block_selects_hash_value
+    n = 0
+    result = {'a' => 1, 'b' => 2, 'c' => 3}
+    source      = cold('  -abc|')
+    expected    = msgs('------(a|)', a: result)
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure do
+      source.to_h do |c|
+        c.value_selector { |v| n += 1 }
+      end
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_key_block
+    source      = cold('  -1')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.to_h do |c|
+        c.key_selector { |v| raise error }
+      end
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  
+  def test_erroring_value_block
+    source      = cold('  -1')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.to_h do |c|
+        c.value_selector { |v| raise error }
+      end
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.to_h }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_selector_configuration_fails_immediately
+    source = cold('  -|')
+    assert_raises(RuntimeError) do
+      source.to_h { |_| raise error }
+    end
+  end
+end


### PR DESCRIPTION
Marble-style tests for operators `.average`, `.count`, `.reduce`, `.scan`, `.sum`, `.to_a` and `.to_h`.

Changelog:
- .scan operator use next instead of break
- .average, .sum generates detailed exceptions on non-numerical input.
- `.to_h` now uses value selector properly.