### PR TITLE
Marble testing .msgs need to be able to do falsy custom values

### DIFF
--- a/lib/rx/testing/marble_testing.rb
+++ b/lib/rx/testing/marble_testing.rb
@@ -33,7 +33,7 @@ module Rx
             on_error(time, v)
           end
         else
-          v = values[event.to_sym] || (Integer(event) rescue event)
+          v = values.fetch(event.to_sym, (Integer(event) rescue event))
           if v.is_a? Proc
             on_next_predicate(time, &v)
           else


### PR DESCRIPTION
Gotcha on #23 which considers any falsy value to be a custom value lookup failure. Change to using `#fetch` with fallback.