### PR TITLE
Cleanup .element_at, .first, .last, .single operators

### DIFF
--- a/lib/rx/operators/aggregates.rb
+++ b/lib/rx/operators/aggregates.rb
@@ -140,39 +140,20 @@ module Rx
       reduce(0) {|c, _| c + 1 }
     end
 
-    # Returns the element at a specified index in a sequence.
+    # Returns the element at a specified index in a sequence. Will raise or return dwfault value if sequence is too short.
     # @param [Numeric] index The zero-based index of the element to retrieve.
+    # @param [Object] default_value The optional default value to use if the index is out of range.
     # @return [Rx::Observable] An observable sequence that produces the element at the specified position in the
     # source sequence.
-    def element_at(index)
-      raise ArgumentError.new 'index cannot be less than zero' if index < 0
-      AnonymousObservable.new do |observer|
-        i = index
-        new_obs = Observer.configure do |o|
-          o.on_next do |value|
-            if i == 0
-              observer.on_next value
-              observer.on_completed
-            end
-
-            i -= 1
-          end
-
-          o.on_error(&observer.method(:on_error))
-          o.on_completed do
-            err = RuntimeError.new('Sequence contains too few elements')
-            observer.on_error(err)
-          end
-        end
-
-        subscribe new_obs
+    def element_at(*args)
+      has_default = false
+      index = args[0]
+      if args.length == 2
+        has_default = true
+        default_value = args[1]
+      elsif args.length > 2
+        raise ArgumentError.new "Expected index and optional default value, received #{args}"
       end
-    end
-
-    # Returns the element at a specified index in a sequence or a default value if the index is out of range.
-    # @param [Numeric] index The zero-based index of the element to retrieve.
-    # @param [Object] default_value The default value to use if the index is out of range.
-    def element_at_or_default(index, default_value = nil)
       raise ArgumentError.new 'index cannot be less than zero' if index < 0
       AnonymousObservable.new do |observer|
         i = index
@@ -187,10 +168,14 @@ module Rx
           end
 
           o.on_error(&observer.method(:on_error))
-
           o.on_completed do
-            observer.on_next default_value
-            observer.on_completed
+            if has_default
+              observer.on_next default_value
+              observer.on_completed
+            else
+              err = RuntimeError.new('Sequence contains too few elements')
+              observer.on_error(err)
+            end
           end
         end
 
@@ -200,11 +185,20 @@ module Rx
 
     # Returns the first element of an observable sequence that satisfies the condition in the predicate if a block is
     # given, else the first item in the observable sequence.
+    # @param [Object] default_value The default value to use if the sequence is empty.
     # @param [Proc] block Optional predicate function to evaluate for elements in the source sequence.
     # @return [Rx::Observable] Sequence containing the first element in the observable sequence that satisfies the
     # condition in the predicate if a block is given, else the first element.
-    def first(&block)
-      return select(&block).first if block_given?
+    def first(*args, &block)
+      return select(&block).first(*args) if block_given?
+      has_default = false
+      if args.length == 1
+        has_default = true
+        default_value = args[0]
+      elsif args.length > 1
+        raise ArgumentError.new "Expected only an optional default value, received #{args}"
+      end
+
       AnonymousObservable.new do |observer|
         new_obs = Observer.configure do |o|
           o.on_next do |x|
@@ -214,41 +208,19 @@ module Rx
 
           o.on_error(&observer.method(:on_error))
           o.on_completed do
-            err = RuntimeError.new('Sequence contains no elements')
-            observer.on_error(err)
+            if has_default
+              observer.on_next default_value
+              observer.on_completed
+            else
+              err = RuntimeError.new('Sequence contains no elements')
+              observer.on_error(err)
+            end
           end
         end
 
         subscribe new_obs
       end
-    end
-
-    # Returns the first element of an observable sequence that satisfies the condition in the predicate if given,
-    # or a default value if no such element exists.
-    # @param [Object] default_value The default value to use if the sequence is empty.
-    # @param [Proc] block An optional predicate function to evaluate for elements in the source sequence.
-    # @return [Rx::Observable] Sequence containing the first element in the observable sequence that satisfies the
-    # condition in the predicate if given, or a default value if no such element exists.
-    def first_or_default(default_value = nil, &block)
-      return select(&block).first_or_default(default_value) if block_given?
-      AnonymousObservable.new do |observer|
-        new_obs = Observer.configure do |o|
-          o.on_next do |x|
-            observer.on_next x
-            observer.on_completed
-          end
-
-          o.on_error(&observer.method(:on_error))
-
-          o.on_completed do
-            observer.on_next default_value
-            observer.on_completed
-          end
-        end
-
-        subscribe new_obs
-      end
-    end
+    end 
 
     # Determines whether an observable sequence is empty.
     # @return [Rx::Observable] An observable sequence containing a single element determining whether the source
@@ -259,11 +231,19 @@ module Rx
 
     # Returns the last element of an observable sequence that satisfies the condition in the predicate if the block is
     # given, else the last element in the observable sequence.
+    # @param [Object] default_value The default value to use if the sequence is empty.
     # @param [Proc] block An predicate function to evaluate for elements in the source sequence.
     # @return {Rx::Observable} Sequence containing the last element in the observable sequence that satisfies the
     # condition in the predicate if given, or the last element in the observable sequence.
-    def last(&block)
-      return select(&block).last if block_given?
+    def last(*args, &block)
+      return select(&block).last(*args) if block_given?
+      has_default = false
+      if args.length == 1
+        has_default = true
+        default_value = args[0]
+      elsif args.length > 1
+        raise ArgumentError.new "Expected only an optional default value, received #{args}"
+      end
       AnonymousObservable.new do |observer|
 
         value = nil
@@ -281,40 +261,13 @@ module Rx
             if seen_value
               observer.on_next value
               observer.on_completed
+            elsif has_default
+              observer.on_next default_value
+              observer.on_completed
             else
-              observer.on_error(RuntimeError.new 'Sequence contains no elements' )
+              err = RuntimeError.new('Sequence contains no elements')
+              observer.on_error(err)
             end
-          end
-        end
-
-        subscribe new_obs
-      end
-    end
-
-    # Returns the last element of an observable sequence that satisfies the condition in the predicate if given, or
-    # a default value if no such element exists.
-    # @param [Object] default_value The default value to use if the sequence is empty.
-    # @param [Proc] block An predicate function to evaluate for elements in the source sequence.
-    # @return {Rx::Observable} Sequence containing the last element in the observable sequence that satisfies the
-    # condition in the predicate if given, or a default value if no such element exists.
-    def last_or_default(default_value = nil, &block)
-      return select(&block).last_or_default(default_value) if block_given?
-      AnonymousObservable.new do |observer|
-
-        value = nil
-        seen_value = false
-
-        new_obs = Observer.configure do |o|
-          o.on_next do |v|
-            value = v
-            seen_value = true
-          end
-
-          o.on_error(&observer.method(:on_error))
-
-          o.on_completed do
-            observer.on_next (seen_value ? value : default_value)
-            observer.on_completed
           end
         end
 

--- a/lib/rx/operators/aggregates.rb
+++ b/lib/rx/operators/aggregates.rb
@@ -159,7 +159,10 @@ module Rx
           end
 
           o.on_error(&observer.method(:on_error))
-          o.on_completed { raise 'Sequence contains no elements' }
+          o.on_completed do
+            err = RuntimeError.new('Sequence contains too few elements')
+            observer.on_error(err)
+          end
         end
 
         subscribe new_obs
@@ -210,7 +213,10 @@ module Rx
           end
 
           o.on_error(&observer.method(:on_error))
-          o.on_completed { raise 'Sequence contains no elements' }
+          o.on_completed do
+            err = RuntimeError.new('Sequence contains no elements')
+            observer.on_error(err)
+          end
         end
 
         subscribe new_obs

--- a/lib/rx/operators/aggregates.rb
+++ b/lib/rx/operators/aggregates.rb
@@ -405,10 +405,18 @@ module Rx
 
     # Returns the only element of an observable sequence, and reports an exception if there is not exactly one
     # element in the observable sequence.
+    # @param [Object] default_value The default value if no value is provided
     # @param [Proc] block A predicate function to evaluate for elements in the source sequence.
     # @return [Rx::Observable] >Sequence containing the single element in the observable sequence.
-    def single(&block)
-      return select(&block).single if block_given?
+    def single(*args, &block)
+      return select(&block).single(*args) if block_given?
+      has_default = false
+      if args.length == 1
+        has_default = true
+        default_value = args[0]
+      elsif args.length > 1
+        raise ArgumentError.new "Expected only an optional default value, received #{args}"
+      end
       AnonymousObservable.new do |observer|
         seen_value = false
         value = nil
@@ -429,43 +437,13 @@ module Rx
             if seen_value
               observer.on_next value
               observer.on_completed
+            elsif has_default
+              observer.on_next default_value
+              observer.on_completed
             else
-              observer.on_error(RuntimeError.new 'Sequence contains no elements')
+              err = RuntimeError.new('Sequence contains no elements')
+              observer.on_error(err)
             end
-          end
-        end
-
-        subscribe new_obs
-      end
-    end
-
-    # Returns the only element of an observable sequence, or a default value if the observable sequence is empty;
-    # this method reports an exception if there is more than one element in the observable sequence.
-    # @param [Object] default_value The default value if no value is provided
-    # @param [Proc] block A predicate function to evaluate for elements in the source sequence.
-    # @return [Rx::Observable] Sequence containing the single element in the observable sequence, or a default value
-    # if no such element exists.
-    def single_or_default(default_value = nil, &block)
-      return select(&block).single_or_default(default_value) if block_given?
-      AnonymousObservable.new do |observer|
-        seen_value = false
-        value = nil
-
-        new_obs = Observer.configure do |o|
-          o.on_next do |x|
-            if seen_value
-              observer.on_error(RuntimeError.new 'More than one element produced')
-            else
-              value = x
-              seen_value = true
-            end
-          end
-
-          o.on_error(&observer.method(:on_error))
-
-          o.on_completed do
-            observer.on_next (seen_value ? value : default_value)
-            observer.on_completed
           end
         end
 

--- a/test/rx/operators/test_element_at.rb
+++ b/test/rx/operators/test_element_at.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class TestOperatorElementAt < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_returns_nth_element
+    left       = cold('  -123|')
+    expected   = msgs('----(2|)')
+    left_subs  = subs('  ^ !')
+
+    actual = scheduler.configure { left.element_at(1) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+  
+  def test_propagates_error
+    left       = cold('  -#')
+    expected   = msgs('---#')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.element_at(0) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_fails_on_empty
+    my_err = ->(err) { err.is_a?(RuntimeError) && err.message.include?('too few elements') }
+
+    left       = cold('  -1|')
+    expected   = msgs('----#', error: my_err)
+    left_subs  = subs('  ^ !')
+
+    actual = scheduler.configure { left.element_at(1) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_raises_on_negative_index
+    left = cold('  -1|')
+    assert_raises(ArgumentError) do
+      left.element_at(-1)
+    end
+  end
+
+  def test_raises_on_non_numerical_index
+    left = cold('  -1|')
+    assert_raises(ArgumentError) do
+      left.element_at('foo')
+    end
+  end
+end
+
+class TestOperatorElementAtOrDefault < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_default_value_on_empty
+    left       = cold('  -|')
+    expected   = msgs('---(2|)')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.element_at_or_default(1, 2) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+end

--- a/test/rx/operators/test_element_at.rb
+++ b/test/rx/operators/test_element_at.rb
@@ -51,17 +51,13 @@ class TestOperatorElementAt < Minitest::Test
       left.element_at('foo')
     end
   end
-end
 
-class TestOperatorElementAtOrDefault < Minitest::Test
-  include Rx::MarbleTesting
-  
   def test_default_value_on_empty
     left       = cold('  -|')
     expected   = msgs('---(2|)')
     left_subs  = subs('  ^!')
 
-    actual = scheduler.configure { left.element_at_or_default(1, 2) }
+    actual = scheduler.configure { left.element_at(1, 2) }
 
     assert_msgs expected, actual
     assert_subs left_subs, left

--- a/test/rx/operators/test_first.rb
+++ b/test/rx/operators/test_first.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+class TestOperatorFirst < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_returns_first
+    left       = cold('  -123|')
+    expected   = msgs('---(1|)')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.first }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+  
+  def test_propagates_error
+    left       = cold('  -#')
+    expected   = msgs('---#')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.first }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_block_selects_first
+    left       = cold('  -123|')
+    expected   = msgs('----(2|)')
+    left_subs  = subs('  ^ !')
+
+    actual = scheduler.configure do
+      left.first { |n| n > 1 }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_erroring_block
+    left       = cold('  -123|')
+    expected   = msgs('---#')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      left.first { |n| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_fails_on_empty
+    my_err = ->(err) { err.is_a?(RuntimeError) && err.message.include?('no elements') }
+
+    left       = cold('  -|')
+    expected   = msgs('---#', error: my_err)
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.first }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+end
+
+class TestOperatorFirstOrDefault < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_default_value_on_empty
+    left       = cold('  -|')
+    expected   = msgs('---(2|)')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.first_or_default(2) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+end

--- a/test/rx/operators/test_first.rb
+++ b/test/rx/operators/test_first.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class TestOperatorFirst < Minitest::Test
   include Rx::MarbleTesting
   
-  def test_returns_first
+  def test_returns_first_value_and_completes
     left       = cold('  -123|')
     expected   = msgs('---(1|)')
     left_subs  = subs('  ^!')
@@ -25,7 +25,7 @@ class TestOperatorFirst < Minitest::Test
     assert_subs left_subs, left
   end
 
-  def test_block_selects_first
+  def test_block_selects_value_to_return
     left       = cold('  -123|')
     expected   = msgs('----(2|)')
     left_subs  = subs('  ^ !')
@@ -51,7 +51,7 @@ class TestOperatorFirst < Minitest::Test
     assert_subs left_subs, left
   end
 
-  def test_fails_on_empty
+  def test_fails_on_empty_sequence
     my_err = ->(err) { err.is_a?(RuntimeError) && err.message.include?('no elements') }
 
     left       = cold('  -|')
@@ -64,7 +64,7 @@ class TestOperatorFirst < Minitest::Test
     assert_subs left_subs, left
   end
   
-  def test_default_value_on_empty
+  def test_default_value_on_empty_sequence
     left       = cold('  -|')
     expected   = msgs('---(2|)')
     left_subs  = subs('  ^!')

--- a/test/rx/operators/test_first.rb
+++ b/test/rx/operators/test_first.rb
@@ -63,17 +63,13 @@ class TestOperatorFirst < Minitest::Test
     assert_msgs expected, actual
     assert_subs left_subs, left
   end
-end
-
-class TestOperatorFirstOrDefault < Minitest::Test
-  include Rx::MarbleTesting
   
   def test_default_value_on_empty
     left       = cold('  -|')
     expected   = msgs('---(2|)')
     left_subs  = subs('  ^!')
 
-    actual = scheduler.configure { left.first_or_default(2) }
+    actual = scheduler.configure { left.first(2) }
 
     assert_msgs expected, actual
     assert_subs left_subs, left

--- a/test/rx/operators/test_last.rb
+++ b/test/rx/operators/test_last.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+class TestOperatorLast < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_returns_last
+    left       = cold('  -123|')
+    expected   = msgs('------(3|)')
+    left_subs  = subs('  ^   !')
+
+    actual = scheduler.configure { left.last }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+  
+  def test_propagates_error
+    left       = cold('  -#')
+    expected   = msgs('---#')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.last }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_block_selects_last
+    left       = cold('  -123|')
+    expected   = msgs('------(2|)')
+    left_subs  = subs('  ^   !')
+
+    actual = scheduler.configure do
+      left.last { |n| n < 3 }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_erroring_block
+    left       = cold('  -123|')
+    expected   = msgs('---#')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      left.last { |n| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_fails_on_empty
+    my_err = ->(err) { err.is_a?(RuntimeError) && err.message.include?('no elements') }
+
+    left       = cold('  -|')
+    expected   = msgs('---#', error: my_err)
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.last }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+end
+
+class TestOperatorLastOrDefault < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_default_value_on_empty
+    left       = cold('  -|')
+    expected   = msgs('---(2|)')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.last_or_default(2) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+end

--- a/test/rx/operators/test_last.rb
+++ b/test/rx/operators/test_last.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class TestOperatorLast < Minitest::Test
   include Rx::MarbleTesting
   
-  def test_returns_last
+  def test_returns_last_value_and_completes
     left       = cold('  -123|')
     expected   = msgs('------(3|)')
     left_subs  = subs('  ^   !')
@@ -25,7 +25,7 @@ class TestOperatorLast < Minitest::Test
     assert_subs left_subs, left
   end
 
-  def test_block_selects_last
+  def test_block_selects_value_emitted_on_completion
     left       = cold('  -123|')
     expected   = msgs('------(2|)')
     left_subs  = subs('  ^   !')
@@ -64,7 +64,7 @@ class TestOperatorLast < Minitest::Test
     assert_subs left_subs, left
   end
 
-  def test_default_value_on_empty
+  def test_emit_default_value_on_empty_sequence
     left       = cold('  -|')
     expected   = msgs('---(2|)')
     left_subs  = subs('  ^!')

--- a/test/rx/operators/test_last.rb
+++ b/test/rx/operators/test_last.rb
@@ -63,17 +63,13 @@ class TestOperatorLast < Minitest::Test
     assert_msgs expected, actual
     assert_subs left_subs, left
   end
-end
 
-class TestOperatorLastOrDefault < Minitest::Test
-  include Rx::MarbleTesting
-  
   def test_default_value_on_empty
     left       = cold('  -|')
     expected   = msgs('---(2|)')
     left_subs  = subs('  ^!')
 
-    actual = scheduler.configure { left.last_or_default(2) }
+    actual = scheduler.configure { left.last(2) }
 
     assert_msgs expected, actual
     assert_subs left_subs, left

--- a/test/rx/operators/test_single.rb
+++ b/test/rx/operators/test_single.rb
@@ -1,0 +1,122 @@
+require 'test_helper'
+
+class TestOperatorSingle < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_returns_single_value_on_completion
+    left       = cold('  -1-|')
+    expected   = msgs('-----(1|)')
+    left_subs  = subs('  ^  !')
+
+    actual = scheduler.configure { left.single }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_fails_on_sequence_with_multiple_values
+    my_err = ->(err) { err.is_a?(RuntimeError) && err.message.include?('More than one') }
+
+    left       = cold('  -12|')
+    expected   = msgs('----#', error: my_err)
+    left_subs  = subs('  ^ !')
+
+    actual = scheduler.configure { left.single }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_propagates_error
+    left       = cold('  -#')
+    expected   = msgs('---#')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.single }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_block_selects_single_value
+    left       = cold('  -123|')
+    expected   = msgs('------(2|)')
+    left_subs  = subs('  ^   !')
+
+    actual = scheduler.configure do
+      left.single { |n| n == 2 }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_fails_on_block_selecting_multiple_values
+    my_err = ->(err) { err.is_a?(RuntimeError) && err.message.include?('More than one') }
+
+    left       = cold('  -22|')
+    expected   = msgs('----#', error: my_err)
+    left_subs  = subs('  ^ !')
+
+    actual = scheduler.configure do
+      left.single { |n| n == 2 }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_erroring_block
+    left       = cold('  -123|')
+    expected   = msgs('---#')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure do
+      left.single { |n| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_fails_on_empty_sequence
+    my_err = ->(err) { err.is_a?(RuntimeError) && err.message.include?('no elements') }
+
+    left       = cold('  -|')
+    expected   = msgs('---#', error: my_err)
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.single }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+end
+
+class TestOperatorSingleOrDefault < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_emits_default_value_on_empty_sequence
+    left       = cold('  -|')
+    expected   = msgs('---(2|)')
+    left_subs  = subs('  ^!')
+
+    actual = scheduler.configure { left.single_or_default(2) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+
+  def test_fails_on_multiple_even_with_default
+    my_err = ->(err) { err.is_a?(RuntimeError) && err.message.include?('More than one') }
+
+    left       = cold('  -12|')
+    expected   = msgs('----#', error: my_err)
+    left_subs  = subs('  ^ !')
+
+    actual = scheduler.configure { left.single_or_default(3) }
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+  end
+end

--- a/test/rx/operators/test_single.rb
+++ b/test/rx/operators/test_single.rb
@@ -91,17 +91,13 @@ class TestOperatorSingle < Minitest::Test
     assert_msgs expected, actual
     assert_subs left_subs, left
   end
-end
-
-class TestOperatorSingleOrDefault < Minitest::Test
-  include Rx::MarbleTesting
 
   def test_emits_default_value_on_empty_sequence
     left       = cold('  -|')
     expected   = msgs('---(2|)')
     left_subs  = subs('  ^!')
 
-    actual = scheduler.configure { left.single_or_default(2) }
+    actual = scheduler.configure { left.single(2) }
 
     assert_msgs expected, actual
     assert_subs left_subs, left
@@ -114,7 +110,7 @@ class TestOperatorSingleOrDefault < Minitest::Test
     expected   = msgs('----#', error: my_err)
     left_subs  = subs('  ^ !')
 
-    actual = scheduler.configure { left.single_or_default(3) }
+    actual = scheduler.configure { left.single(3) }
 
     assert_msgs expected, actual
     assert_subs left_subs, left


### PR DESCRIPTION
Marble-style tests for .element_at, .first, .last, .single. This PR also removes the special *_or_default methods just as RxJS has done.

Changelog:
- remove .element_at_or_default, .first_or_default, .last_or_default, .single_or_default operators and equip .element_at, .first, .last, .single with optional default value parameters.
- .first, .element_at now on_errors rather than raise on "sequence contains no elements"