### PR TITLE
Cleanup .any?, .all?, .contains?, .empty?, .none? operators

### DIFF
--- a/test/rx/operators/test_all.rb
+++ b/test/rx/operators/test_all.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+class TestOperatorAll < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_emit_false_on_first_falsy_value
+    source       = cold('  -f11|', f: false)
+    expected     = msgs('---(f|)', f: false)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.all? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emit_true_for_sequence_of_truthy_values
+    source       = cold('  -t1|', t: true)
+    expected     = msgs('-----(t|)', t: true)
+    source_subs  = subs('  ^  !')
+
+    actual = scheduler.configure { source.all? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emit_true_on_empty_sequence
+    source       = cold('  -|')
+    expected     = msgs('---(t|)', t: true)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.all? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source       = cold('  -#')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.all? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_true_when_all_elements_match_block
+    source       = cold('  -123|')
+    expected     = msgs('------(t|)', t: true)
+    source_subs  = subs('  ^   !')
+
+    actual = scheduler.configure { source.all? { |n| n > 0 } }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_false_when_one_element_fails_block
+    source       = cold('  -123|')
+    expected     = msgs('----(f|)', f: false)
+    source_subs  = subs('  ^ !')
+
+    actual = scheduler.configure { source.all? { |n| n != 2 } }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block
+    source       = cold('  -123|')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.all? { |n| raise error } }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_any.rb
+++ b/test/rx/operators/test_any.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+class TestOperatorAny < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_emit_true_on_first_truthy_element
+    source       = cold('  -123|')
+    expected     = msgs('---(t|)', t: true)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.any? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emit_false_on_sequence_of_falsy_values
+    source       = cold('  -nnn|', n: nil)
+    expected     = msgs('------(f|)', f: false)
+    source_subs  = subs('  ^   !')
+
+    actual = scheduler.configure { source.any? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emit_false_on_empty_sequence
+    source       = cold('  -|')
+    expected     = msgs('---(f|)', f: false)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.any? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source       = cold('  -#')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.any? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_true_on_first_element_selected_by_block
+    source       = cold('  -123|')
+    expected     = msgs('----(t|)', t: true)
+    source_subs  = subs('  ^ !')
+
+    actual = scheduler.configure { source.any? { |n| n > 1 } }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_false_when_block_returns_false_on_all
+    source       = cold('  -123|')
+    expected     = msgs('------(f|)', f: false)
+    source_subs  = subs('  ^   !')
+
+    actual = scheduler.configure { source.any? { |n| false } }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block
+    source       = cold('  -123|')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.any? { |n| raise error } }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_contains.rb
+++ b/test/rx/operators/test_contains.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class TestOperatorContains < Minitest::Test
+  include Rx::MarbleTesting
+
+  class This
+    def ==(other)
+      false
+    end
+
+    def eql?(other)
+      other.is_a? This
+    end
+  end
+
+  class That
+    def ==(other)
+      false
+    end
+
+    def eql?(other)
+      other.is_a? That
+    end
+  end
+
+  def test_emit_true_on_first_eql_match
+    source       = cold('  -aba|', a: That.new, b: This.new)
+    expected     = msgs('----(t|)', t: true)
+    source_subs  = subs('  ^ !')
+
+    actual = scheduler.configure { source.contains?(This.new) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emit_false_when_no_eql_match
+    source       = cold('  -aaa|', a: That.new)
+    expected     = msgs('------(f|)', f: false)
+    source_subs  = subs('  ^   !')
+
+    actual = scheduler.configure { source.contains?(This.new) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emit_false_on_empty
+    source       = cold('  -|')
+    expected     = msgs('---(f|)', f: false)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.contains?(This.new) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source       = cold('  -#')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.contains?('foo') }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_empty.rb
+++ b/test/rx/operators/test_empty.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class TestOperatorEmpty < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_emut_false_for_any_values
+    source       = cold('  -a|')
+    expected     = msgs('---(f|)', f: false)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.empty? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_true_on_empty
+    source       = cold('  -|')
+    expected     = msgs('---(t|)', t: true)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.empty? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source       = cold('  -#')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.empty? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_none.rb
+++ b/test/rx/operators/test_none.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+class TestOperatorNone < Minitest::Test
+  include Rx::MarbleTesting
+  
+  def test_emit_false_for_any_truthy_values
+    source       = cold('  -a|')
+    expected     = msgs('---(f|)', f: false)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.none? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emit_true_for_all_falsy_sequence
+    source       = cold('  -fnfn|', f: false, n: nil)
+    expected     = msgs('-------(t|)', t: true)
+    source_subs  = subs('  ^    !')
+
+    actual = scheduler.configure { source.none? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emit_true_on_empty_sequence
+    source       = cold('  -|')
+    expected     = msgs('---(t|)', t: true)
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.none? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source       = cold('  -#')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.none? }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_true_when_no_elements_match_block
+    source       = cold('  -123|')
+    expected     = msgs('------(t|)', t: true)
+    source_subs  = subs('  ^   !')
+
+    actual = scheduler.configure { source.none? { |n| n < 1 } }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_false_when_one_element_matches_block
+    source       = cold('  -123|')
+    expected     = msgs('----(f|)', f: false)
+    source_subs  = subs('  ^ !')
+
+    actual = scheduler.configure { source.none? { |n| n == 2 } }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block
+    source       = cold('  -123|')
+    expected     = msgs('---#')
+    source_subs  = subs('  ^!')
+
+    actual = scheduler.configure { source.none? { |n| raise error } }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end


### PR DESCRIPTION
Marble-style tests for Cleanup `.any?`, `.all?`, `.contains?`, `.empty?`, `.none?` operators.

Changelog:
- `.any?` need to apply block with `.select` rather than `.map` as `.map` will always emit, triggering `.any?` regardless of block output.
- `.none?` needs to `.select` according to block (rather than block negation) since `.any?` is fail-fast and then map-invert the result (like `.all?`).