### PR TITLE
Subject allows all Observable forms of subscription

### DIFF
--- a/lib/rx/subjects/subject.rb
+++ b/lib/rx/subjects/subject.rb
@@ -73,8 +73,7 @@ module Rx
       os.each {|o| o.on_next value } if os      
     end
 
-    # Subscribes an observer to the subject.
-    def subscribe(observer)
+    def _subscribe(observer)
       raise 'observer cannot be nil' unless observer
 
       @gate.synchronize do

--- a/test/rx/subjects/test_subject.rb
+++ b/test/rx/subjects/test_subject.rb
@@ -1,6 +1,99 @@
 require 'test_helper'
 
-class TestBehaviorSubject < Minitest::Test
+class TestSubject < Minitest::Test
+  include Rx::ReactiveTest
+
+  def setup
+    @subject = Rx::Subject.new
+    @observer1 = Rx::MockObserver.new(scheduler)
+    @observer2 = Rx::MockObserver.new(scheduler)
+    @err = RuntimeError.new
+  end
+
+  def test_subscribe_observer
+    @subject.subscribe(@observer1)
+    @subject.on_next(1)
+    expected = [on_next(0, 1)]
+    assert_messages expected, @observer1.messages
+  end
+
+  def test_subscribe_block
+    messages = []
+    @subject.subscribe { |m| messages << m }
+    @subject.on_next(1)
+    assert_raises(@err.class) do
+      @subject.on_error(@err)
+    end
+    @subject.on_completed
+    assert_equal [1], messages
+  end
+
+  def subscribe_triple_lambda
+    messages = []
+    @subject.subscribe(
+      lambda { |m| messages << m },
+      lambda { |err| messages << err },
+      lambda { messages << :complete }
+    )
+    @subject.on_next(1)
+    @subject.on_error(@err)
+    @subject.on_completed
+    assert_equal [1, @err, :complete], messages
+  end
+
+  def test_allows_multiple_subscribers
+    @subject.subscribe(@observer1)
+    @subject.subscribe(@observer2)
+    @subject.on_next(1)
+    @subject.on_next(2)
+    @subject.on_completed
+    expected = [
+      on_next(0, 1),
+      on_next(0, 2),
+      on_completed(0)
+    ]
+    assert_messages expected, @observer1.messages
+    assert_messages expected, @observer2.messages
+  end
+
+  def test_subscribe_to_completed_completes
+    @subject.on_completed
+    @subject.subscribe(@observer1)
+    assert_equal [on_completed(0)], @observer1.messages
+  end
+
+  def test_subscribe_to_erroring_errors
+    @subject.on_error(@err)
+    @subject.subscribe(@observer1)
+    assert_equal [on_error(0, @err)], @observer1.messages
+  end
+
+  def test_unsubscribe_observer_stops_emitting
+    s1 = @subject.subscribe(@observer1)
+    s2 = @subject.subscribe(@observer2)
+    @subject.on_next(1)
+    s1.unsubscribe
+    @subject.on_next(2)
+    assert_messages [on_next(0, 1)], @observer1.messages
+    assert_messages [on_next(0, 1), on_next(0, 2)], @observer2.messages
+  end
+
+  def test_unsubscribe_disposes_subject
+    @subject.unsubscribe
+    assert_raises(ArgumentError) do
+      @subject.subscribe(@observer1)
+    end
+    assert_raises(ArgumentError) do
+      @subject.on_next(1)
+    end
+    assert_raises(ArgumentError) do
+      @subject.on_error(@err)
+    end
+    assert_raises(ArgumentError) do
+      @subject.on_completed
+    end
+  end
+
   def test_unsubscribe_through_autodetach_observer
     subject = Rx::Subject.new
     subject.map {|_| }.subscribe { }


### PR DESCRIPTION
`Rx::Subject` should allow the normal subscription styles that `Observable.subscribe` uses - it is an Observable, after all. This PR simply uses the `subscribe` method from `Rx::Observable` to normalize the observer setup and instead overrides `_subscribe`. This also fixes a bug where `.to_a` assumed that you could use the three-lambda subscription form on itself: https://github.com/bittrance/rxruby/blob/caea16f7e723e8ea6f2241210abae5009b1827c6/lib/rx/operators/aggregates.rb#L523.

Since test coverage for Subject was lacking, this branch also adds those.