### PR TITLE
Tests for .take_last, .skip_last

### DIFF
--- a/lib/rx/operators/single.rb
+++ b/lib/rx/operators/single.rb
@@ -310,28 +310,6 @@ module Rx
       end
     end
 
-    # Returns a list with the specified number of contiguous elements from the end of an observable sequence.
-    def take_last_buffer(count)
-      AnonymousObservable.new do |observer|
-        q = []
-        new_obs = Observer.configure do |o|
-          o.on_next do |x|
-            q.push x
-            q.shift if q.length > count
-          end
-
-          o.on_error(&observer.method(:on_error))
-
-          o.on_completed do
-            observer.on_next q
-            observer.on_completed
-          end
-        end
-
-        susbcribe new_obs
-      end
-    end
-
     # Projects each element of an observable sequence into zero or more windows which are produced based on element count information.
     def window_with_count(count, skip)
       raise ArgumentError.new 'Count must be greater than zero' if count <= 0

--- a/lib/rx/operators/single.rb
+++ b/lib/rx/operators/single.rb
@@ -288,7 +288,7 @@ module Rx
         new_obs = Observer.configure do |o|
           o.on_next do |x|
             q.push x
-            q.shift if q.length > 0
+            q.shift if q.length > count
           end
 
           o.on_error(&observer.method(:on_error))
@@ -303,10 +303,9 @@ module Rx
               end
             })
           end
-
-          g.add(subscribe new_obs)
-          g
         end
+
+        g << subscribe(new_obs)
       end
     end
 

--- a/test/rx/operators/test_skip_last.rb
+++ b/test/rx/operators/test_skip_last.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class TestOperatorSkipLast < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_skip_last_emitted_values
+    source      = cold('  -123456|')
+    expected    = msgs('------123|')
+    source_subs = subs('  ^      !')
+
+    actual = scheduler.configure { source.skip_last(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emits_nothing_when_fewer_than_count
+    source      = cold('  -123|')
+    expected    = msgs('------|')
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure { source.skip_last(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.skip_last(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_completion
+    source      = cold('  -|')
+    expected    = msgs('---|')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.skip_last(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_argument_error_on_negative_count
+    source = cold('  -|')
+    assert_raises(ArgumentError) do
+      source.skip_last(-1)
+    end
+  end
+end

--- a/test/rx/operators/test_take_last.rb
+++ b/test/rx/operators/test_take_last.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class TestOperatorTakeLast < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_emit_last_values_on_completion
+    source      = cold('  -123456|')
+    expected    = msgs('---------(456|)')
+    source_subs = subs('  ^      !')
+
+    actual = scheduler.configure { source.take_last(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emits_all_elements_when_fewer_than_count
+    source      = cold('  -12|')
+    expected    = msgs('-----(12|)')
+    source_subs = subs('  ^  !')
+
+    actual = scheduler.configure { source.take_last(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.take_last(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_completion
+    source      = cold('  -|')
+    expected    = msgs('---|')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.take_last(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_argument_error_on_negative_count
+    source = cold('  -|')
+    assert_raises(ArgumentError) do
+      source.take_last(-1)
+    end
+  end
+end


### PR DESCRIPTION
Marble-style tests for `.take_last` and `.skip_last`.

Changelog:
- remove `.take_last_buffer`. Use `.take_last(n).to_a` instead; this mehtod is no longer in RxJS either.
- `.take_last` now emits the correct number of items, rather than always emitting zero elements