### PR TITLE
Tests for .sequence_eql?

### DIFF
--- a/lib/rx/operators/aggregates.rb
+++ b/lib/rx/operators/aggregates.rb
@@ -322,6 +322,7 @@ module Rx
         left_queue = []
         right_queue = []
 
+        subscription1 = SingleAssignmentSubscription.new
         obs1 = Observer.configure do |o|
           o.on_next do |x|
             gate.synchronize do
@@ -357,11 +358,13 @@ module Rx
                 end
               end
             end
+            subscription1.unsubscribe
           end
         end
 
-        subscription1 = subscribe obs1
+        subscription1.subscription = subscribe obs1
 
+        subscription2 = SingleAssignmentSubscription.new
         obs2 = Observer.configure do |o|
           o.on_next do |x|
             gate.synchronize do
@@ -397,10 +400,11 @@ module Rx
                 end
               end
             end
+            subscription2.unsubscribe
           end
         end
 
-        subscription2 = other.subscribe obs2
+        subscription2.subscription = other.subscribe obs2
 
         CompositeSubscription.new [subscription1, subscription2]
       end

--- a/test/rx/operators/test_sequence_eql.rb
+++ b/test/rx/operators/test_sequence_eql.rb
@@ -1,0 +1,197 @@
+require 'test_helper'
+
+class TestOperatorSequenceEql < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_true_when_left_disjunct_identical_sequences
+    left       = cold('  123|')
+    right      = cold('  ----123|')
+    expected   = msgs('---------(t|)', t: true)
+    left_subs  = subs('  ^  !')
+    right_subs = subs('  ^      !')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_false_when_left_disjunct_sequence_differs
+    left       = cold('  12|')
+    right      = cold('  ----123|')
+    expected   = msgs('--------(f|)', f: false)
+    left_subs  = subs('  ^ !')
+    right_subs = subs('  ^     !')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_false_on_first_left_difference_in_disjunct_seq
+    left       = cold('  -124|')
+    right      = cold('  -----123|')
+    expected   = msgs('---------(f|)', f: false)
+    left_subs  = subs('  ^   !')
+    right_subs = subs('  ^      !')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_false_on_overlapping_with_right_queue_on_left_complete
+    left       = cold('  -12-|')
+    right      = cold('  -123-|')
+    expected   = msgs('------(f|)', f: false)
+    left_subs  = subs('  ^   !')
+    right_subs = subs('  ^   !')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_true_when_left_two_empty_sequences
+    left       = cold('  -|')
+    right      = cold('  --|')
+    expected   = msgs('----(t|)', t: true)
+    left_subs  = subs('  ^!')
+    right_subs = subs('  ^ !')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_true_when_parallel_identical_sequences_left
+    left       = cold('  -123|')
+    right      = cold('  -123---|')
+    expected   = msgs('---------(t|)', t: true)
+    left_subs  = subs('  ^   !')
+    right_subs = subs('  ^      !')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_true_when_right_disjunct_identical_sequences
+    left       = cold('  ----123|')
+    right      = cold('  123|')
+    expected   = msgs('---------(t|)', t: true)
+    left_subs  = subs('  ^      !')
+    right_subs = subs('  ^  !')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_false_when_right_disjunct_sequence_differs
+    left       = cold('  ----123|')
+    right      = cold('  12|')
+    expected   = msgs('--------(f|)', f: false)
+    left_subs  = subs('  ^     !')
+    right_subs = subs('  ^ !')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_false_on_first_right_difference_in_disjunct_seq
+    left       = cold('  -----123|')
+    right      = cold('  -124|')
+    expected   = msgs('---------(f|)', f: false)
+    left_subs  = subs('  ^      !')
+    right_subs = subs('  ^   !')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_false_on_overlapping_with_left_queue_on_right_complete
+    left       = cold('  -123-|')
+    right      = cold('  -12-|')
+    expected   = msgs('------(f|)', f: false)
+    left_subs  = subs('  ^   !')
+    right_subs = subs('  ^   !')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_true_when_right_two_empty_sequences
+    left       = cold('  --|')
+    right      = cold('  -|')
+    expected   = msgs('----(t|)', t: true)
+    left_subs  = subs('  ^ !')
+    right_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+
+  def test_true_when_parallel_identical_sequences_right
+    left       = cold('  -123---|')
+    right      = cold('  -123|')
+    expected   = msgs('---------(t|)', t: true)
+    left_subs  = subs('  ^      !')
+    right_subs = subs('  ^   !')
+
+    actual = scheduler.configure do
+      left.sequence_eql?(right)
+    end
+
+    assert_msgs expected, actual
+    assert_subs left_subs, left
+    assert_subs right_subs, right
+  end
+end


### PR DESCRIPTION
Marble-style tests for `.sequence_eql?`.

Changelog:
- `.sequence_eql?` now unsubscribes completed sequences immediately, rather than when the slowest sequence completes.