### PR TITLE
Cleanup .materialize, .dematerialize operators

### DIFF
--- a/lib/rx/operators/single.rb
+++ b/lib/rx/operators/single.rb
@@ -148,7 +148,7 @@ module Rx
           o.on_next {|x| observer.on_next(Notification.create_on_next x) }
 
           o.on_error do |err|
-            observer.on_next(Notification.create_on_next err)
+            observer.on_next(Notification.create_on_error err)
             observer.on_completed
           end
 

--- a/test/rx/operators/test_dematerialize.rb
+++ b/test/rx/operators/test_dematerialize.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+
+class TestOperatorDematerialize < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_dematerialize_on_next
+    source      = cold('  -a|', a: Rx::Notification.create_on_next('a'))
+    expected    = msgs('---a|')
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure { source.dematerialize }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_dematerialize_on_error
+    source      = cold('  -a|', a: Rx::Notification.create_on_error(error))
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.dematerialize }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+  
+  def test_dematerialize_on_completed
+    source      = cold('  -a|', a: Rx::Notification.create_on_completed)
+    expected    = msgs('---|')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.dematerialize }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.dematerialize }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_completion
+    source      = cold('  -|')
+    expected    = msgs('---|')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.dematerialize }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_materialize.rb
+++ b/test/rx/operators/test_materialize.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class TestOperatorMaterialize < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_materialize_on_next_and_on_completed
+    source      = cold('  -a|')
+    expected    = msgs('---a(b|)', a: Rx::Notification.create_on_next('a'), b: Rx::Notification.create_on_completed)
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure { source.materialize }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_materialize_on_next_and_on_error
+    source      = cold('  -a#')
+    expected    = msgs('---a(b|)', a: Rx::Notification.create_on_next('a'), b: Rx::Notification.create_on_error(error))
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure { source.materialize }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end


### PR DESCRIPTION
Marble-style tests for `.materialize`, `.dematerialize`.

Changelog:
- `.materialize` now emits errors as `on_error` notifications (rather than `on_next` notifications)