### PR TITLE
Tests for .distinct, .distinct_until_changed operators

### DIFF
--- a/test/rx/operators/test_distinct.rb
+++ b/test/rx/operators/test_distinct.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class TestOperatorDistinct < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_emit_only_unique_items
+    source      = cold('  -112231|')
+    expected    = msgs('---1-2-3-|')
+    source_subs = subs('  ^      !')
+
+    actual = scheduler.configure { source.distinct }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_respects_nil_as_value
+    source      = cold('  -aab|', a: nil)
+    expected    = msgs('---a-b|', a: nil)
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure { source.distinct }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_block_selects_value_for_uniqueness_test
+    source      = cold('  -1325|')
+    expected    = msgs('---1-2-|')
+    source_subs = subs('  ^    !')
+
+    actual = scheduler.configure do
+      source.distinct { |x| x % 2 == 0 }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+  
+  def test_erroring_block
+    source      = cold('  -1|')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.distinct { raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.distinct }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_completion
+    source      = cold('  -|')
+    expected    = msgs('---|')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.distinct }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_distinct_until_changed.rb
+++ b/test/rx/operators/test_distinct_until_changed.rb
@@ -1,0 +1,88 @@
+require 'test_helper'
+
+class TestOperatorDistinctUntilChanged < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_emit_value_if_different_from_previous
+    source      = cold('  1122231|')
+    expected    = msgs('--1-2--31|')
+    source_subs = subs('  ^      !')
+
+    actual = scheduler.configure { source.distinct_until_changed }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_respects_nil_as_value
+    source      = cold('  -aab|', a: nil)
+    expected    = msgs('---a-b|', a: nil)
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure { source.distinct_until_changed }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_block_compares
+    source      = cold('  -123|')
+    expected    = msgs('---1-3|')
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure do
+      source.distinct_until_changed do |l, r|
+        l + 1 == r
+      end
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_block_does_not_see_first_value
+    source = cold('  -123|')
+    n = 0
+
+    scheduler.configure do
+      source.distinct_until_changed { n += 1 }
+    end
+    
+    assert_equal 2, n
+  end
+
+  def test_erroring_block
+    source      = cold('  -12|')
+    expected    = msgs('---1#')
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure do
+      source.distinct_until_changed { raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.distinct_until_changed }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_completion
+    source      = cold('  -|')
+    expected    = msgs('---|')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.distinct_until_changed }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_ignores_elements.rb
+++ b/test/rx/operators/test_ignores_elements.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TestOperatorDistinct < Minitest::Test
+class TestOperatorIgnoreElements < Minitest::Test
   include Rx::MarbleTesting
 
   def test_ony_outputs_on_completed


### PR DESCRIPTION
Marble-style tests for `.distinct`, `.distinct_until_changed`.

Changelog:
- `.distinct_until_changed` now accepts a comparator function, using `<=>` for default.
- `.distinct_until_changed` now accepts `nil` as an ordinary element.