### PR TITLE
Tests for standard query operators (.map, .select, .skip, .take and friends)

### DIFF
--- a/lib/rx/operators/standard_query_operators.rb
+++ b/lib/rx/operators/standard_query_operators.rb
@@ -161,9 +161,8 @@ module Rx
                 observer.on_error e
                 next
               end
-
-              observer.on_next x if running
             end
+            observer.on_next x if running
           end
 
           o.on_error(&observer.method(:on_error))

--- a/lib/rx/operators/standard_query_operators.rb
+++ b/lib/rx/operators/standard_query_operators.rb
@@ -116,6 +116,7 @@ module Rx
 
     # Bypasses a specified number of elements in an observable sequence and then returns the remaining elements.
     def skip(count)
+      raise ArgumentError.new 'Count must be at least zero' if count < 0
       AnonymousObservable.new do |observer|
         remaining = count
 
@@ -174,8 +175,9 @@ module Rx
     end
 
     # Returns a specified number of contiguous elements from the start of an observable sequence.
-    def take(count, scheduler = ImmediateScheduler.instance)
-      return Observable.empty(scheduler) if count == 0
+    def take(count)
+      raise ArgumentError.new 'Count must be at least zero' if count < 0
+      return Observable.empty if count == 0
 
       AnonymousObservable.new do |observer|
 

--- a/test/rx/operators/test_default_if_empty.rb
+++ b/test/rx/operators/test_default_if_empty.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+class TestOperatorDefaultIfEmpty < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_default_if_empty
+    source      = cold('  -|')
+    expected    = msgs('---(9|)')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.default_if_empty(9) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_no_default_on_emission
+    source      = cold('  -1|')
+    expected    = msgs('---1|')
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure { source.default_if_empty(9) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.default_if_empty(9) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_map_with_index.rb
+++ b/test/rx/operators/test_map_with_index.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+class TestOperatorMap < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_replaces_value_with_block_result
+    source      = cold('  -123|')
+    expected    = msgs('---234|')
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure do
+      source.map { |x| x + 1 }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end
+
+class TestOperatorMapWithIndex < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_replaces_value_with_block_result
+    source      = cold('  -123|')
+    expected    = msgs('---abc|', a: [0, 2], b: [1, 3], c: [2, 4])
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure do
+      source.map_with_index { |x, i| [i, x + 1] }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_respects_nil_as_value
+    source      = cold('  -a|', a: nil)
+    expected    = msgs('---a|', a: nil)
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure do
+      source.map_with_index { |x, _| x }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block
+    source      = cold('  -1')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.map_with_index { raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.map_with_index { |x, i| [i, x] }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_map_with_index.rb
+++ b/test/rx/operators/test_map_with_index.rb
@@ -72,3 +72,50 @@ class TestOperatorMapWithIndex < Minitest::Test
     assert_subs source_subs, source
   end
 end
+
+class TestOperatorFlatMap < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_flattens_output_from_block
+    a           = cold('   1-3|')
+    b           = cold('    2-4--|')
+    c           = cold('     --5|')
+    source      = cold('  -abc|')
+    expected    = msgs('---12345-|')
+    source_subs = subs('  ^   !')
+    a_subs      = subs('   ^  !')
+    b_subs      = subs('    ^    !')
+    c_subs      = subs('     ^  !')
+
+    actual = scheduler.configure do
+      source.flat_map do |x|
+        {'a' => a, 'b' => b, 'c' => c}.fetch(x)
+      end
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs c_subs, c
+  end
+end
+
+class TestOperatorFlatMapWithIndex < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_flattens_output_from_indexing_block
+    source      = cold('  -12345|')
+    expected    = msgs('---13579|')
+    source_subs = subs('  ^     !')
+
+    actual = scheduler.configure do
+      source.flat_map_with_index do |x, i|
+        Rx::Observable.just(x + i)
+      end
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_select_with_index.rb
+++ b/test/rx/operators/test_select_with_index.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+class TestOperatorSelect < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_replaces_value_with_block_result
+    source      = cold('  -123456|')
+    expected    = msgs('----2-4-6|')
+    source_subs = subs('  ^      !')
+
+    actual = scheduler.configure do
+      source.select { |x| x % 2 == 0 }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end
+
+class TestOperatorSelectWithIndex < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_block_filters_values
+    source      = cold('  -11335|')
+    expected    = msgs('---1-3-5|')
+    source_subs = subs('  ^     !')
+
+    actual = scheduler.configure do
+      source.select_with_index { |x, i| x > i }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_respects_nil_as_a_value
+    source      = cold('  -a|', a: nil)
+    expected    = msgs('---a|', a: nil)
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure do
+      source.select_with_index { |x, _| true }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block
+    source      = cold('  -1')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.select_with_index { raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.select_with_index { |x, i| [i, x] }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_skip.rb
+++ b/test/rx/operators/test_skip.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class TestOperatorSkip < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_skip_first_three_values
+    source      = cold('  -123456|')
+    expected    = msgs('------456|')
+    source_subs = subs('  ^      !')
+
+    actual = scheduler.configure { source.skip(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emit_nothing_on_complete_before_skip_count
+    source      = cold('  -12|')
+    expected    = msgs('-----|')
+    source_subs = subs('  ^  !')
+
+    actual = scheduler.configure { source.skip(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_skip_nothing_on_zero
+    source      = cold('  -123|')
+    expected    = msgs('---123|')
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure { source.skip(0) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.skip(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+  
+  def test_require_positive_count
+    source = cold('  -|')
+    assert_raises(ArgumentError) do
+      source.skip(-1)
+    end
+  end
+end

--- a/test/rx/operators/test_skip_while_with_index.rb
+++ b/test/rx/operators/test_skip_while_with_index.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+class TestOperatorSkipWhile < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_ignore_values_until_block_falsy
+    source      = cold('  -123456|')
+    expected    = msgs('------456|')
+    source_subs = subs('  ^      !')
+
+    actual = scheduler.configure do
+      source.skip_while { |x| x < 4 }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end
+
+class TestOperatorSkipWhileWithIndex < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_ignore_values_until_block_falsy
+    source      = cold('  -54321|')
+    expected    = msgs('------21|')
+    source_subs = subs('  ^     !')
+
+    actual = scheduler.configure do
+      source.skip_while_with_index { |x, i| x > i }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_stops_calling_block_after_false
+    call_count = 0
+    source = cold('  -54321|')
+
+    scheduler.configure do
+      source.skip_while_with_index do |x, i|
+        call_count += 1
+        x > i
+      end
+    end
+    assert_equal 4, call_count
+  end
+
+  def test_respects_nil_as_value
+    source      = cold('  -a|', a: nil)
+    expected    = msgs('---a|', a: nil)
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure do
+      source.skip_while_with_index { |x, _| false }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block
+    source      = cold('  -1')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.skip_while_with_index { |_, _| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.skip_while_with_index { |x, i| [i, x] }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/operators/test_take.rb
+++ b/test/rx/operators/test_take.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class TestOperatorTake < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_emit_only_first_three_values_and_complete
+    source      = cold('  -123456|')
+    expected    = msgs('---12(3|)')
+    source_subs = subs('  ^  !')
+
+    actual = scheduler.configure { source.take(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_complete_before_take_count
+    source      = cold('  -12|')
+    expected    = msgs('---12|')
+    source_subs = subs('  ^  !')
+
+    actual = scheduler.configure { source.take(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emit_nothing_on_count_zero
+    source      = cold('  -123|')
+    expected    = msgs('--|')
+    source_subs = subs('   ')
+
+    actual = scheduler.configure { source.take(0) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure { source.take(3) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+  
+  def test_require_positive_count
+    source = cold('  -|')
+    assert_raises(ArgumentError) do
+      source.take(-1)
+    end
+  end
+end

--- a/test/rx/operators/test_take_while_with_index.rb
+++ b/test/rx/operators/test_take_while_with_index.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+class TestOperatorTakeWhile < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_emit_values_until_block_falsy
+    source      = cold('  -123456|')
+    expected    = msgs('---123|')
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure do
+      source.take_while { |x| x < 4 }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end
+
+class TestOperatorTakeWhileWithIndex < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_emit_values_until_block_falsy
+    source      = cold('  -54321|')
+    expected    = msgs('---543|')
+    source_subs = subs('  ^   !')
+
+    actual = scheduler.configure do
+      source.take_while_with_index { |x, i| x > i }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_respects_nil_as_value
+    source      = cold('  -a|', a: nil)
+    expected    = msgs('---a|', a: nil)
+    source_subs = subs('  ^ !')
+
+    actual = scheduler.configure do
+      source.take_while_with_index { |x, _| true }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_block
+    source      = cold('  -1')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.take_while_with_index { |_, _| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('  ^!')
+
+    actual = scheduler.configure do
+      source.take_while_with_index { |x, i| [i, x] }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end


### PR DESCRIPTION
Marble-style tests for:
- `.default_if_empty`
- `.map`, `.map_with_index`
- `.select`, `.select_with_index`
- `.skip`, `skip_while`, `.skip_while_with_index`
- `.take`, `.take_while`, `.take_while_with_index`

Changelog:
- `.skip_while`, `.skip_while_with_entry` now continue emitting elements after they stop skipping.
- `.skip`, `.take` now throws `ArgumentError` on negative count