### PR TITLE
Marbles use a unique error clas

### DIFF
--- a/lib/rx/testing/marble_testing.rb
+++ b/lib/rx/testing/marble_testing.rb
@@ -4,8 +4,10 @@ module Rx
   module MarbleTesting
     include Rx::ReactiveTest
 
+    class MyError < RuntimeError ; end
+
     def error
-      @err ||= RuntimeError.new
+      @err ||= MyError.new
     end
 
     def msgs(events, values = {})


### PR DESCRIPTION
RuntimeError occasionally arise out of bugs or misformulated test. This PR switches to a unique error class for all marble specs in order to avoid mistakenly masking errors in any test using `#` marbles.