### PR TITLE
Subscription unsubscribe only calls action once

### DIFF
--- a/lib/rx/subscriptions/subscription.rb
+++ b/lib/rx/subscriptions/subscription.rb
@@ -34,6 +34,7 @@ module Rx
       should_unsubscribe = false
       @gate.synchronize do
         should_unsubscribe = !@unsubscribed
+        @unsubscribed = true
       end
 
       @unsubscribe_action.call if should_unsubscribe

--- a/test/rx/subscriptions/test_subscription.rb
+++ b/test/rx/subscriptions/test_subscription.rb
@@ -10,12 +10,14 @@ class TestSubscription < Minitest::Test
   end
 
   def test_create_dispose
-    unsubscribed = false
-    d = Rx::Subscription.create { unsubscribed = true }
-    refute unsubscribed
+    unsubscribed = 0
+    d = Rx::Subscription.create { unsubscribed += 1 }
+    assert_equal 0, unsubscribed
 
     d.unsubscribe
-    assert unsubscribed
+    assert_equal 1, unsubscribed
+    d.unsubscribe
+    assert_equal 1, unsubscribed
   end
 
   def test_empty


### PR DESCRIPTION
`Subscription.unsubscribe` now remembers that it has been called before so that it won't call unsubscribe action more than once.  Since there was already a `synchronize` block, it seems this is simply an oversight in original implementation.