### PR TITLE
Time-based recursive actions provide a subscription so that cancellatation works properly

### DIFF
--- a/lib/rx/testing/async_testing.rb
+++ b/lib/rx/testing/async_testing.rb
@@ -21,12 +21,10 @@ module Rx
       flunk "Array expected to be at least #{expected} items but was #{array}"
     end
 
-    private
-
     def await_criteria(timeout)
       deadline = Time.now + timeout
       while Time.now < deadline
-        sleep timeout / 10
+        sleep timeout / 20
         return true if yield
       end
       return false

--- a/test/rx/concurrency/test_default_scheduler.rb
+++ b/test/rx/concurrency/test_default_scheduler.rb
@@ -37,12 +37,10 @@ class TestDefaultScheduler < Minitest::Test
   end
 
   def test_schedule_recursive_absolute_non_recursive
-    state = []
-    task = ->(a) { state << 1; a.call(Time.now) }
+    task = ->(a) { a.call(Time.now) }
 
     subscription = @scheduler.schedule_recursive_absolute(Time.now, task)
-    await_array_minimum_length(state, 3)
-    assert_equal(1, subscription.subscription.length)
+    await_criteria(2) { subscription.subscription && subscription.subscription.length == 1 }
     subscription.unsubscribe
   end
 

--- a/test/rx/concurrency/test_default_scheduler.rb
+++ b/test/rx/concurrency/test_default_scheduler.rb
@@ -36,6 +36,16 @@ class TestDefaultScheduler < Minitest::Test
     refute_equal([id], state)
   end
 
+  def test_schedule_recursive_absolute_non_recursive
+    state = []
+    task = ->(a) { state << 1; a.call(Time.now) }
+
+    subscription = @scheduler.schedule_recursive_absolute(Time.now, task)
+    await_array_minimum_length(state, 3)
+    assert_equal(1, subscription.subscription.length)
+    subscription.unsubscribe
+  end
+
   def test_schedule_action_cancel
     task = -> { flunk "This should not run." }
     subscription = @scheduler.schedule_relative(0.05, task)


### PR DESCRIPTION
In the progress of working with `.timer` I discovered that it did not receive a proper subscription and so could not do cancellation. This was because the scheduler helper that handles absolute time did not actually append a proper subscription to the composite subscription it returns.

Test is on default scheduler as it is the one most likely to encounter absolute time.