### PR TITLE
Cleanup operators .concat_map, .concat_map_observer, .concat_all

### DIFF
--- a/test/rx/linq/observable/test_concat_all.rb
+++ b/test/rx/linq/observable/test_concat_all.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class TestOperatorConcatAll < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_concat_sequences
+    a           = cold('  12-|')
+    b           = cold('     3-4|')
+    source      = cold('  ab|', a: a, b: b)
+    expected    = msgs('--12-3-4|')
+    a_subs      = subs('--^--!')
+    b_subs      = subs('-----^--!')
+    source_subs = subs('--^-----!') # FIXME: should unsubscribe 400
+
+    actual = scheduler.configure { source.concat_all }
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/linq/observable/test_concat_map.rb
+++ b/test/rx/linq/observable/test_concat_map.rb
@@ -1,0 +1,145 @@
+require 'test_helper'
+
+class TestOperatorConcatMap < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_concat_two_sequences_with_selector
+    a           = cold('  12-|')
+    b           = cold('     3-4|')
+    source      = cold('  ab|', a: a, b: b)
+    expected    = msgs('--12-4-5|')
+    a_subs      = subs('--^--!')
+    b_subs      = subs('-----^--!')
+    source_subs = subs('--^-!')
+
+    actual = scheduler.configure do
+      source.concat_map(
+        lambda { |x, i| x.map { |v| v + i } }
+      )
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs source_subs, source
+  end
+
+  def test_concat_two_sequences_with_single_value
+    source      = cold('  1-1|')
+    expected    = msgs('--3-43-4|')
+    source_subs = subs('--^--!')
+
+    actual = scheduler.configure do
+      source.concat_map(cold('3-4|'))
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_concat_two_sequences_with_array
+    source      = cold('  1-1|')
+    expected    = msgs('--(34)-(34)|')
+    source_subs = subs('--^--!')
+
+    actual = scheduler.configure do
+      source.concat_map([3, 4])
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_concat_two_sequences_with_result_selector
+    a           = cold('  12-|')
+    b           = cold('     3-4|')
+    source      = cold('  ab|', a: a, b: b)
+    expected    = msgs('--pq-r-s|', p: [1, 0, 0], q: [2, 0, 1], r: [3, 1, 0], s: [4, 1, 1])
+    a_subs      = subs('--^--!')
+    b_subs      = subs('-----^--!')
+    source_subs = subs('--^-!')
+
+    actual = scheduler.configure do
+      source.concat_map(
+        lambda { |x, i| x },
+        lambda { |_, *args| args }
+      )
+    end
+
+    assert_msgs expected, actual
+    assert_subs a_subs, a
+    assert_subs b_subs, b
+    assert_subs source_subs, source
+  end
+
+  def test_concat_sequences_with_inner_array
+    source      = cold('  a-b|', a: [1, 2], b: [3, 4])
+    expected    = msgs('--(12)-(34)|')
+    source_subs = subs('--^--!')
+
+    actual = scheduler.configure do
+      source.concat_map(
+        lambda { |x, i| x },
+        lambda { |_, y, _, _| y }
+      )
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_selector_raises
+    source      = cold('  -1')
+    expected    = msgs('---#')
+    source_subs = subs('--^!')
+
+    actual = scheduler.configure do
+      source.concat_map(lambda { |*_| raise error })
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_selector_error
+    source      = cold('  -1')
+    expected    = msgs('---#')
+    source_subs = subs('--^!')
+
+    actual = scheduler.configure do
+      source.concat_map(lambda { |*_| cold('#') })
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_result_selector_raises
+    source      = cold('  -1')
+    expected    = msgs('---#')
+    source_subs = subs('--^!')
+
+    actual = scheduler.configure do
+      source.concat_map(
+        lambda { |*_| cold('1') },
+        lambda { |*_| raise error }
+      )
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagates_error
+    source      = cold('  -#')
+    expected    = msgs('---#')
+    source_subs = subs('--^!')
+
+    actual = scheduler.configure do
+      source.concat_map(lambda { |x, i| x })
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/linq/observable/test_concat_map_observer.rb
+++ b/test/rx/linq/observable/test_concat_map_observer.rb
@@ -1,0 +1,108 @@
+require 'test_helper'
+
+class TestOperatorConcatMapObserver < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_map_with_index
+    source      = cold('  123|')
+    expected    = msgs('--135|')
+    source_subs = subs('--^--!')
+
+    actual = scheduler.configure do
+      source.concat_map_observer(
+        lambda { |x, i| cold("#{x + i}|") },
+        lambda { |err| err },
+        lambda { cold('|') },
+      )
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_next_raises
+    source      = cold('  1|')
+    expected    = msgs('--#')
+    source_subs = subs('--(^!)')
+
+    actual = scheduler.configure do
+      source.concat_map_observer(
+        lambda { |x, i| raise error },
+        lambda { |err| },
+        lambda { },
+      )
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_handle_error
+    source      = cold('  -#')
+    expected    = msgs('---a|')
+    source_subs = subs('--^!')
+
+    actual = scheduler.configure do
+      source.concat_map_observer(
+        lambda { |x, i| },
+        lambda { |err| cold('a|') },
+        lambda { },
+      )
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_map_error_raises
+    other_err   = RuntimeError.new
+    source      = cold('  -#')
+    expected    = msgs('---#', error: other_err)
+    source_subs = subs('--^!')
+
+    actual = scheduler.configure do
+      source.concat_map_observer(
+        lambda { |x, i| },
+        lambda { |err| raise other_err },
+        lambda { },
+      )
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_handle_completion
+    source      = cold('  -|')
+    expected    = msgs('---a|')
+    source_subs = subs('--^!')
+
+    actual = scheduler.configure do
+      source.concat_map_observer(
+        lambda { |x, i| },
+        lambda { |err| },
+        lambda { cold('a|') },
+      )
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_completion_raises
+    source      = cold('  -|')
+    expected    = msgs('---#')
+    source_subs = subs('--^!')
+
+    actual = scheduler.configure do
+      source.concat_map_observer(
+        lambda { |x, i| },
+        lambda { |err| },
+        lambda { raise error },
+      )
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end


### PR DESCRIPTION
Marble-style tests for `.concat_map`, `.concat_map_observer`, `.concat_all`.

No changelog entries.