### PR TITLE
Observable.subscribe detects when passed an observer by looking for on_next

### DIFF
--- a/lib/rx/core/observable.rb
+++ b/lib/rx/core/observable.rb
@@ -19,7 +19,7 @@ module Rx
           _subscribe Observer.configure
         end
       when 1
-        raise ArgumentError.new 'Must pass observer as single argument' unless args[0].is_a? ObserverBase
+        raise ArgumentError.new 'Must pass observer as single argument' unless args[0].respond_to? :on_next
         _subscribe args[0]
       when 3
         _subscribe Observer.configure {|o|


### PR DESCRIPTION
Commit 1be9cf4b introduced an error message when passed strange observers by checking for `ObserverBase` superclass. However, it is reasonable to pass a`Subject` to `#subscribe` which would fail with this strategy as it is not a subclass of `ObserverBase`. Let's switch to duck-typing for this check.