### PR TITLE
Cleanup ConnectableObservable and .multicast, .publish

### DIFF
--- a/lib/rx/linq/connectable_observable.rb
+++ b/lib/rx/linq/connectable_observable.rb
@@ -18,6 +18,7 @@ module Rx
     end
 
     def ref_count
+      raise 'Cannot create ref counter when already connected' if @has_subscription
       count = 0
       gate = Mutex.new
       connectable_subscription = nil

--- a/lib/rx/linq/observable/multicast.rb
+++ b/lib/rx/linq/observable/multicast.rb
@@ -5,7 +5,7 @@ module Rx
         selector ||= lambda { |c| c.connect ; c }
         AnonymousObservable.new do |observer|
           connectable = self.multicast(subject_or_subject_selector.call)
-          CompositeSubscription.new [selector.call(connectable).subscribe(observer), self]
+          selector.call(connectable).subscribe(observer)
         end
       else
         ConnectableObservable.new(self, subject_or_subject_selector)

--- a/lib/rx/linq/observable/multicast.rb
+++ b/lib/rx/linq/observable/multicast.rb
@@ -2,6 +2,7 @@ module Rx
   module Observable
     def multicast(subject_or_subject_selector, selector = nil)
       if Proc === subject_or_subject_selector
+        selector ||= lambda { |c| c.connect ; c }
         AnonymousObservable.new do |observer|
           connectable = self.multicast(subject_or_subject_selector.call)
           CompositeSubscription.new [selector.call(connectable).subscribe(observer), self]

--- a/lib/rx/linq/observable/publish.rb
+++ b/lib/rx/linq/observable/publish.rb
@@ -2,7 +2,7 @@ module Rx
   module Observable
     def publish(&selector)
       if block_given?
-        multicast(lambda { Subject.new }, Proc.new)
+        multicast(lambda { Subject.new }, selector)
       else
         multicast(Subject.new)
       end

--- a/lib/rx/testing/marble_testing.rb
+++ b/lib/rx/testing/marble_testing.rb
@@ -89,5 +89,10 @@ module Rx
       messages = msgs(events, values)
       scheduler.create_cold_observable(*messages)
     end
+
+    def hot(events, values = {})
+      messages = msgs(events, values)
+      scheduler.create_hot_observable(*messages)
+    end
   end
 end

--- a/test/rx/linq/observable/test_multicast.rb
+++ b/test/rx/linq/observable/test_multicast.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+
+class TestOperatorMulticast < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_single_subject
+    # Note manual subscribe @ 100
+    source      = cold(' -123|')
+    expected    = msgs('--123|')
+    source_subs = subs('-^---!')
+
+    subject_obs = scheduler.create_observer
+    actual = scheduler.configure do
+      subject = Rx::Subject.new
+      subject.subscribe(subject_obs)
+      obs = source.multicast(subject)
+      obs.connect
+      obs
+    end
+
+    assert_msgs expected, actual
+    assert_msgs expected, subject_obs
+    assert_subs source_subs, source
+  end
+
+  def test_subject_from_proc
+    source      = cold('  -123|')
+    expected    = msgs('---123|')
+    source_subs = subs('--^---!')
+
+    subject_obs = scheduler.create_observer
+    actual = scheduler.configure do
+      make_subject = lambda do
+        subject = Rx::Subject.new
+        subject.subscribe(subject_obs)
+        subject
+      end
+      source.multicast(make_subject)
+    end
+
+    assert_msgs expected, actual
+    assert_msgs expected, subject_obs
+    assert_subs source_subs, source
+  end
+
+  def test_subject_selector
+    source      = cold('  -123|')
+    expected    = msgs('---234|')
+    source_subs = subs('--^---!')
+
+    subject_obs = scheduler.create_observer
+    actual = scheduler.configure do
+      make_subject = lambda do
+        subject = Rx::Subject.new
+        subject.subscribe(subject_obs)
+        subject
+      end
+      source.multicast(make_subject, lambda do |connectable|
+        connectable.connect
+        connectable.map { |n| n + 1 }
+      end)
+    end
+
+    assert_msgs expected, actual
+    assert_msgs msgs('---123|'), subject_obs
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/linq/observable/test_publish.rb
+++ b/test/rx/linq/observable/test_publish.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class TestOperatorPublish < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_single_subject
+    # Note manual subscribe @ 100
+    source      = cold(' -123|')
+    expected    = msgs('--123|')
+    source_subs = subs('-^---!')
+
+    actual = scheduler.configure do
+      obs = source.publish
+      obs.connect
+      obs
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_subject_selector
+    source      = cold('  -123|')
+    expected    = msgs('---234|')
+    source_subs = subs('--^---!')
+
+    actual = scheduler.configure do
+      source.publish do |connectable|
+        connectable.connect
+        connectable.map { |n| n + 1 }
+      end
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+end

--- a/test/rx/linq/observable/test_start.rb
+++ b/test/rx/linq/observable/test_start.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class TestOperatorStart < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_return_result_with_context
+    expected = msgs('--(a|)')
+
+    context = Struct.new(:result).new('a')
+    actual = scheduler.configure do
+      Rx::Observable.start(lambda { self.result }, context, scheduler)
+    end
+
+    assert_msgs expected, actual
+  end
+end

--- a/test/rx/linq/observable/test_to_async.rb
+++ b/test/rx/linq/observable/test_to_async.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class TestOperatorToAsync < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_return_result
+    expected = msgs('--(1|)')
+
+    actual = scheduler.configure do
+      Rx::Observable.to_async(lambda { 1 }, nil, scheduler).call
+    end
+
+    assert_msgs expected, actual
+  end
+
+  def test_call_with_arguments
+    expected = msgs('--(2|)')
+
+    actual = scheduler.configure do
+      Rx::Observable.to_async(lambda { |x| x }, nil, scheduler).call(2)
+    end
+
+    assert_msgs expected, actual
+  end
+
+  def test_return_result_with_context
+    expected = msgs('--(a|)')
+
+    context = Struct.new(:result).new('a')
+    actual = scheduler.configure do
+      Rx::Observable.to_async(lambda { self.result }, context, scheduler).call
+    end
+
+    assert_msgs expected, actual
+  end
+
+  def test_propagates_error
+    expected = msgs('--#')
+
+    actual = scheduler.configure do
+      Rx::Observable.to_async(lambda { raise error }, nil, scheduler).call
+    end
+
+    assert_msgs expected, actual
+  end
+end

--- a/test/rx/linq/test_connectable_observable.rb
+++ b/test/rx/linq/test_connectable_observable.rb
@@ -1,0 +1,124 @@
+require 'test_helper'
+
+class TestConnectableObservable < Minitest::Test
+  include Rx::MarbleTesting
+
+  def setup
+    @observer = scheduler.create_observer
+    @subject1 = Rx::Subject.new
+    @subject1_observer = scheduler.create_observer
+    @subject1.subscribe(@subject1_observer)
+  end
+
+  def test_no_values_without_connect
+    source = cold('1-2|')
+    connectable = Rx::ConnectableObservable.new(source, @subject1)
+    connectable.subscribe(@observer)
+    scheduler.advance_to(700)
+    assert_msgs [], @observer
+    assert_msgs [], @subject1_observer
+    assert_subs [], source
+  end
+
+  def test_subscribe_to_source_on_connect
+    source = cold('1-2|')
+    connectable = Rx::ConnectableObservable.new(source, @subject1)
+    connectable.subscribe(@observer)
+    scheduler.advance_to(300)
+    connectable.connect
+    scheduler.advance_to(700)
+    assert_msgs msgs('---1-2|'), @observer
+    assert_msgs msgs('---1-2|'), @subject1_observer
+    assert_subs subs('---^--!'), source
+  end
+
+  def test_reconnection
+    source = hot('1-2-3-4-5|')
+    connectable = Rx::ConnectableObservable.new(source, @subject1)
+    connectable.subscribe(@observer)
+    s1 = connectable.connect
+    scheduler.advance_to(300)
+    s1.unsubscribe
+    scheduler.advance_to(500)
+    connectable.connect
+    scheduler.advance_to(900)
+    assert_msgs msgs('1-2---4-5|'), @observer
+    assert_msgs msgs('1-2---4-5|'), @subject1_observer
+    assert_subs subs('^--!-^---!'), source
+  end
+
+  def test_propagates_error
+    source = cold('-#')
+    connectable = Rx::ConnectableObservable.new(source, @subject1)
+    connectable.subscribe(@observer)
+    connectable.connect
+    scheduler.advance_to(700)
+    assert_msgs msgs('-#'), @observer
+    assert_msgs msgs('-#'), @subject1_observer
+    assert_subs subs('^!'), source
+  end
+
+  def test_ref_counting
+    source = cold('123456')
+
+    connectable = Rx::ConnectableObservable.new(source, @subject1)
+    connectable.subscribe(@observer)
+    counter = connectable.ref_count
+    o1 = scheduler.create_observer
+    s1 = counter.subscribe(o1)
+    scheduler.advance_to(99)
+    o2 = scheduler.create_observer
+    s2 = counter.subscribe(o2)
+    scheduler.advance_to(200)
+    s1.unsubscribe
+    scheduler.advance_to(300)
+    s2.unsubscribe
+    scheduler.advance_to(700)
+
+    assert_msgs msgs('1234'), @observer
+    assert_msgs msgs('1234'), @subject1_observer
+    assert_msgs msgs('123-'), o1
+    assert_msgs msgs('-234'), o2
+    assert_subs subs('^  !'), source
+  end
+
+  def test_ref_counting_not_affected_by_unsubscribe
+    source = cold('1234')
+
+    connectable = Rx::ConnectableObservable.new(source, @subject1)
+    s1 = connectable.subscribe(@observer)
+    counter = connectable.ref_count
+    o1 = scheduler.create_observer
+    counter.subscribe(o1)
+    scheduler.advance_to(100)
+    s1.unsubscribe
+    scheduler.advance_to(700)
+
+    assert_msgs msgs('1234'), o1
+  end
+
+  def test_ref_counting_propagates_error
+    source = cold('-#')
+
+    connectable = Rx::ConnectableObservable.new(source, @subject1)
+    connectable.subscribe(@observer)
+    counter = connectable.ref_count
+    o1 = scheduler.create_observer
+    counter.subscribe(o1)
+    scheduler.advance_to(200)
+
+    assert_msgs msgs('-#'), @observer
+    assert_msgs msgs('-#'), o1
+    assert_subs subs('^!'), source
+  end
+
+  def test_ref_counting_fails_when_connected
+    source = cold('-#')
+
+    connectable = Rx::ConnectableObservable.new(source, @subject1)
+    connectable.connect
+    assert_raises(RuntimeError) do
+      connectable.ref_count
+    end
+  end
+end


### PR DESCRIPTION
Marble-style tests for `.multicast`, `.publish`, `.to_async`. 

Changelog entries:
- `ConnectableObservable.ref_count` counts references properly and unsubscribes on last.
- `ConnectableObservable.ref_count` now raises when it has already been `.connect`:ed
- `.multicast` defaults to transparent selector so you don't have to give two arguments
- `.multicast` subscribes properly to its connectable
- `.publish` block is now properly optional
