### PR TITLE
Cleanup operators .while and .pluck. Remove .pairs

### DIFF
--- a/lib/rx/linq/observable/pairs.rb
+++ b/lib/rx/linq/observable/pairs.rb
@@ -1,7 +1,0 @@
-module Rx
-  class << Observable
-    def pairs(obj, scheduler = CurrentThreadScheduler.instance)
-      of_enumerable(obj, scheduler)
-    end
-  end
-end

--- a/test/rx/linq/observable/test_pluck.rb
+++ b/test/rx/linq/observable/test_pluck.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class TestOperatorPluck < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_emit_property_of_hash
+    source      = cold('  ab|', a: {p: 1}, b: {})
+    expected    = msgs('--1n|', n: nil)
+    source_subs = subs('--^-!')
+
+    actual = scheduler.configure { source.pluck(:p) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_emit_positional_of_array
+    source      = cold('  ab|', a: [0, 1], b: [])
+    expected    = msgs('--1n|', n: nil)
+    source_subs = subs('--^-!')
+
+    actual = scheduler.configure { source.pluck(1) }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
+
+  def test_propagate_error
+    source      = cold('  #')
+    expected    = msgs('--#')
+
+    actual = scheduler.configure { source.pluck(:p) }
+
+    assert_msgs expected, actual
+  end
+
+  def test_propagate_internal_error
+    source      = cold('  n|', n: nil)
+    expected    = msgs('--#', error: ->(err) { err.is_a? NoMethodError })
+
+    actual = scheduler.configure { source.pluck(:p) }
+
+    assert_msgs expected, actual
+  end
+end

--- a/test/rx/linq/observable/test_while.rb
+++ b/test/rx/linq/observable/test_while.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class TestObservableWhile < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_condition_completes
+    i = 0
+    source = cold('1-2|')
+    actual = scheduler.configure do
+      Rx::Observable.while(lambda { (i += 1) < 3 }, source)
+    end
+
+    assert_msgs msgs('--1-21-2|'), actual
+    assert_subs subs('--^--(!^)--!'), source
+    assert_equal i, 3
+  end
+
+  def test_unsubscribe_while_emitting
+    observer = scheduler.create_observer
+    s1 = Rx::Observable.while(
+      lambda { true },
+      cold('1-2|')
+    ).subscribe(observer)
+    scheduler.advance_to(400)
+    s1.unsubscribe
+    scheduler.advance_to(600)
+
+    assert_msgs msgs('1-21-'), observer
+  end
+
+  def test_break_on_error
+    source      = cold('  #')
+    source_subs = subs('  (^!)')
+    i = 0
+    actual = scheduler.configure do
+      Rx::Observable.while(lambda { (i += 1) < 3 }, source)
+    end
+
+    assert_msgs msgs('--#'), actual
+    assert_subs source_subs, source
+  end
+
+  def test_erroring_condition
+    source      = cold('  1')
+
+    actual = scheduler.configure do
+      Rx::Observable.while(lambda { raise error }, source)
+    end
+    assert_msgs msgs('--#'), actual
+    assert_subs [], source
+  end
+end


### PR DESCRIPTION
Marble-style tests for `.while`, `.pluck`.

Changelog entries:
- remove `.pairs` which is not correctly implemented and is anyway just `.buffer_with_count(2)`.