### PR TITLE
Complete test coverage of Observer and Observable

### DIFF
--- a/test/rx/core/test_observable.rb
+++ b/test/rx/core/test_observable.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class TestAnonymousObservable < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_subscribe_invalid_args_two_lambda
+    assert_raises(ArgumentError) do
+      Rx::AnonymousObservable.new do |obs|
+      end.subscribe(lambda {}, lambda {})
+    end
+  end
+
+  def test_failure_in_subscribe_block
+    observer = scheduler.create_observer
+    Rx::AnonymousObservable.new do |obs|
+      raise error
+    end.subscribe(observer)
+
+    assert_msgs msgs('#'), observer
+  end
+
+  def test_failure_after_stopped_in_subscribe_block
+    observer = scheduler.create_observer
+    assert_raises(error.class) do
+      Rx::AnonymousObservable.new do |obs|
+        obs.on_completed
+        raise error
+      end.subscribe(observer)
+    end
+
+    assert_msgs msgs('|'), observer
+  end
+end

--- a/test/rx/core/test_observer.rb
+++ b/test/rx/core/test_observer.rb
@@ -384,6 +384,35 @@ class TestObserver < Minitest::Test
     assert_equal 1, n
   end
 
+  def test_dont_fail_exactly_once
+    n = 0
+
+    o = Rx::Observer.configure do |obs|
+      obs.on_next {|x| }
+      obs.on_error {|err| n += 1 }
+      obs.on_completed { }
+    end
+
+    assert o.fail(RuntimeError.new)
+    refute o.fail(RuntimeError.new)
+    assert_equal 1, n
+  end
+
+
+  def test_dont_fail_already_stopped_error
+    n = 0
+
+    o = Rx::Observer.configure do |obs|
+      obs.on_next {|x| }
+      obs.on_error {|err| n += 1 }
+      obs.on_completed { }
+    end
+
+    o.on_completed
+    refute o.fail(RuntimeError.new)
+    assert_equal 0, n
+  end
+
   def test_checked_reentrant_next
     n = 0
 


### PR DESCRIPTION
This PR adds test coverage for some bits of `Observer` and `Observable` modules that lacked it.