### PR TITLE
Cleanup ScheduledObserver and .observe_on, remove ObserveOnObserver

### DIFF
--- a/lib/rx/core/observe_on_observer.rb
+++ b/lib/rx/core/observe_on_observer.rb
@@ -8,43 +8,7 @@ module Rx
   module Observer
     # Schedules the invocation of observer methods on the given scheduler.
     def notify_on(scheduler)
-      ObserveOnObserver.new(scheduler, self, nil)
-    end
-  end
-
-  class ObserveOnObserver < ScheduledObserver
-
-    def initialize(scheduler, observer, cancel = nil)
-      @cancel = cancel
-
-      super(scheduler, observer)      
-    end
-
-    def on_next_core(value)
-      ensure_active
-      super(value)
-    end
-
-    def on_error_core(error)
-      ensure_active
-      super(error)
-    end
-
-    def on_completed_core
-      ensure_active
-      super
-    end
-
-    def unsubscribe
-      super
-
-      cancel = nil
-      Mutex.new.synchronize do
-        cancel = @cancel
-        @cancel = nil
-      end
-
-      canel.unsubscribe if cancel
+      ScheduledObserver.new(scheduler, self)
     end
   end
 end

--- a/lib/rx/core/scheduled_observer.rb
+++ b/lib/rx/core/scheduled_observer.rb
@@ -37,7 +37,7 @@ module Rx
        @gate.synchronize { @queue.push(lambda { @observer.on_completed }) }
     end
 
-    def ensure_active(n=0)
+    def ensure_active
       owner = false
 
       @gate.synchronize do
@@ -63,11 +63,11 @@ module Rx
 
       begin
         work.call
-      rescue => e
+      rescue => err
         @queue = []
         @faulted = true
-
-        raise e
+        @observer.on_error err
+        return
       end
 
       recurse.call state

--- a/lib/rx/operators/synchronization.rb
+++ b/lib/rx/operators/synchronization.rb
@@ -27,13 +27,13 @@ module Rx
         d
       end
     end
-  
+
     # Wraps the source sequence in order to run its observer callbacks on the specified scheduler.
     def observe_on(scheduler)
       raise ArgumentError.new 'Scheduler cannot be nil' unless scheduler
 
       AnonymousObservable.new do |observer|
-        subscribe(ObserveOnObserver.new scheduler, observer)
+        subscribe(observer.notify_on(scheduler))
       end
     end
 

--- a/test/rx/core/test_scheduled_observer.rb
+++ b/test/rx/core/test_scheduled_observer.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+
+class TestScheduledObserver < Minitest::Test
+  include Rx::MarbleTesting
+
+  def setup
+    @observer = scheduler.create_observer
+    @another_scheduler = Rx::TestScheduler.new
+    @protagonist = Rx::ScheduledObserver.new(@another_scheduler, @observer)
+  end
+
+  def test_uses_separate_scheduler_for_on_next
+    source = cold('-123|')
+    source.subscribe(@protagonist)
+    scheduler.advance_to(200)
+    assert_msgs [], @observer
+    @another_scheduler.advance_to(200)
+    assert_msgs msgs('--(12)'), @observer
+    scheduler.advance_to(400)
+    assert_msgs msgs('--(12)'), @observer
+    @another_scheduler.advance_to(400)
+    assert_msgs msgs('--(12)-(3|)'), @observer
+  end
+
+  def test_uses_separate_scheduler_for_on_error
+    source = cold('-#')
+    source.subscribe(@protagonist)
+    scheduler.advance_to(200)
+    assert_msgs [], @observer
+    @another_scheduler.advance_to(200)
+    assert_msgs msgs('--#'), @observer
+  end
+
+  def test_stops_on_erroring_observer
+    flaky_observer = Rx::Observer.configure do |o|
+      o.on_next do |x|
+        if x == 'X'
+          raise error
+        else
+          @observer.on_next(x)
+        end
+      end
+      o.on_error(&@observer.method(:on_error))
+      o.on_completed(&@observer.method(:on_completed))
+    end
+    protagonist = Rx::ScheduledObserver.new(scheduler, flaky_observer)
+    source = cold('-1X1')
+    source.subscribe(protagonist)
+    scheduler.advance_to(400)
+    assert_msgs msgs('-1#'), @observer
+  end
+
+  def test_unsubscribe_stops_scheduled_actions
+    source = cold('-123|')
+    source.subscribe(@protagonist)
+    scheduler.advance_to(200)
+    @another_scheduler.advance_to(200)
+    scheduler.advance_to(400)
+    assert_msgs msgs('--(12)'), @observer
+    @protagonist.unsubscribe
+    @another_scheduler.advance_to(400)
+    assert_msgs msgs('--(12)'), @observer
+  end
+end

--- a/test/rx/operators/test_observe_on.rb
+++ b/test/rx/operators/test_observe_on.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class TestOperatorObserveOn < Minitest::Test
+  include Rx::MarbleTesting
+
+  def test_notification_on_another_scheduler
+    source      = cold('1-2-')
+    expected    = msgs('---(1-2)')
+    source_subs = subs('^--!')
+
+    another_scheduler = Rx::TestScheduler.new
+    actual = scheduler.create_observer
+    s1 = source.observe_on(another_scheduler).subscribe(actual)
+
+    another_scheduler.advance_to(300)
+    scheduler.advance_to(300)
+
+    assert_msgs [], actual
+
+    another_scheduler.advance_to(400)
+
+    assert_msgs expected, actual
+    s1.unsubscribe
+    assert_subs source_subs, source
+  end
+
+  def test_unsubscribe_stops_notification
+    source      = cold('1-2-')
+
+    another_scheduler = Rx::TestScheduler.new
+    actual = scheduler.create_observer
+    s1 = source.observe_on(another_scheduler).subscribe(actual)
+
+    another_scheduler.advance_to(300)
+    scheduler.advance_to(300)
+    s1.unsubscribe
+    another_scheduler.advance_to(400)
+
+    assert_msgs [], actual
+  end
+end


### PR DESCRIPTION
Tests for `ScheduledObserver` and `.observe_on`. Remove `ObserveObObserver`.

Changelog entries:
- remove `ObserveOnObserver` and make its superclass `ScheduledObsever` take its place.
- `ScheduledObserver` passes error to wrapped observer or it is very likely to "disappear" since we are very likely to be on a thread.
