### PR TITLE
Tests .multicast, .publish for raising factory and selector

### DIFF
--- a/lib/rx/linq/observable/multicast.rb
+++ b/lib/rx/linq/observable/multicast.rb
@@ -8,6 +8,9 @@ module Rx
           selector.call(connectable).subscribe(observer)
         end
       else
+        unless selector.nil?
+          raise ArgumentError, 'When passing single subject, selector is not supported.'
+        end
         ConnectableObservable.new(self, subject_or_subject_selector)
       end
     end

--- a/test/rx/linq/observable/test_multicast.rb
+++ b/test/rx/linq/observable/test_multicast.rb
@@ -23,7 +23,7 @@ class TestOperatorMulticast < Minitest::Test
     assert_subs source_subs, source
   end
 
-  def test_subject_from_proc
+  def test_subject_from_factory
     source      = cold('  -123|')
     expected    = msgs('---123|')
     source_subs = subs('--^---!')
@@ -40,6 +40,21 @@ class TestOperatorMulticast < Minitest::Test
 
     assert_msgs expected, actual
     assert_msgs expected, subject_obs
+    assert_subs source_subs, source
+  end
+
+  def test_factory_raises
+    source      = cold('  -1|')
+    expected    = msgs('--#')
+    source_subs = subs('')
+
+    scheduler.create_observer
+    actual = scheduler.configure do
+      make_subject = lambda { raise error }
+      source.multicast(make_subject)
+    end
+
+    assert_msgs expected, actual
     assert_subs source_subs, source
   end
 
@@ -64,5 +79,33 @@ class TestOperatorMulticast < Minitest::Test
     assert_msgs expected, actual
     assert_msgs msgs('---123|'), subject_obs
     assert_subs source_subs, source
+  end
+
+  def test_selector_raises
+    source      = cold(' -1|')
+    expected    = msgs('--#')
+    source_subs = subs('')
+
+    subject_obs = scheduler.create_observer
+    actual = scheduler.configure do
+      make_subject = lambda do
+        subject = Rx::Subject.new
+        subject.subscribe(subject_obs)
+        subject
+      end
+      source.multicast(make_subject, lambda { |*_| raise error })
+    end
+
+    assert_msgs expected, actual
+    assert_msgs [], subject_obs
+    assert_subs source_subs, source
+  end
+
+  def test_refuse_simple_subject_with_selector
+    source = cold(' -1|')
+    subject = Rx::Subject.new
+    assert_raises(ArgumentError) do
+      source.multicast(subject, lambda { |*_| })
+    end
   end
 end

--- a/test/rx/linq/observable/test_publish.rb
+++ b/test/rx/linq/observable/test_publish.rb
@@ -34,4 +34,17 @@ class TestOperatorPublish < Minitest::Test
     assert_msgs expected, actual
     assert_subs source_subs, source
   end
+
+  def test_selector_raises
+    source      = cold('  -1|')
+    expected    = msgs('--#')
+    source_subs = subs('')
+
+    actual = scheduler.configure do
+      source.publish { |_| raise error }
+    end
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
+  end
 end


### PR DESCRIPTION
PR #53 seems to have been merged prematurely as `.multicast`, `.publish` had no tests for raising closures. The PR adds those tests.

Changelog entries:
- `.multicast` does not accept selector when passed a single subject. 