### PR TITLE
Test scheduler does absolute time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
     - stage: canary
       rvm: 2.4.0
     - stage: test
-      rvm: jruby-19mode
+      rvm: jruby-9.1.17.0
     - stage: test
       rvm: 1.9.3
     - stage: test

--- a/lib/rx/concurrency/virtual_time_scheduler.rb
+++ b/lib/rx/concurrency/virtual_time_scheduler.rb
@@ -54,33 +54,32 @@ module Rx
     # Schedules an action to be executed.
     def schedule_with_state(state, action)
       raise 'action cannot be nil' unless action
-      schedule_at_absolute_with_state(state, @clock, action)
+      schedule_absolute_with_state(state, @clock, action)
     end
 
     # Schedules an action to be executed at due_time.
-    def schedule_at_relative(due_time, action)
+    def schedule_relative(due_time, action)
       raise 'action cannot be nil' unless action
 
-      schedule_at_relative_with_state(action, due_time, method(:invoke))
+      schedule_relative_with_state(action, due_time, method(:invoke))
     end
 
     # Schedules an action to be executed at due_time.
-    def schedule_at_relative_with_state(state, due_time, action)
+    def schedule_relative_with_state(state, due_time, action)
       raise 'action cannot be nil' unless action
 
-      schedule_at_absolute_with_state(state, @clock + due_time, action)
+      schedule_absolute_with_state(state, @clock + due_time, action)
     end
-    alias_method :schedule_relative_with_state, :schedule_at_relative_with_state
 
     # Schedules an action to be executed at due_time.
-    def schedule_at_absolute(due_time, action)
+    def schedule_absolute(due_time, action)
       raise 'action cannot be nil' unless action
 
-      schedule_at_absolute_with_state(action, due_time, method(:invoke))      
+      schedule_absolute_with_state(action, due_time, method(:invoke))
     end
 
     # Schedules an action to be executed at due_time.
-    def schedule_at_absolute_with_state(state, due_time, action)
+    def schedule_absolute_with_state(state, due_time, action)
       raise 'action cannot be nil' unless action
 
       si = nil
@@ -94,7 +93,6 @@ module Rx
 
       Subscription.create { si.cancel }
     end
-    alias_method :schedule_absolute_with_state, :schedule_at_absolute_with_state
 
     # Advances the scheduler's clock to the specified time, running all work till that point.
     def advance_to(time)

--- a/lib/rx/testing/cold_observable.rb
+++ b/lib/rx/testing/cold_observable.rb
@@ -30,7 +30,7 @@ module Rx
       messages.each do |message|
         notification = message.value
 
-        d.push(@scheduler.schedule_at_relative_with_state(nil, message.time, lambda {|scheduler1, state1|
+        d.push(@scheduler.schedule_relative_with_state(nil, message.time, lambda {|scheduler1, state1|
           notification.accept observer
           Subscription.empty
         }))

--- a/lib/rx/testing/hot_observable.rb
+++ b/lib/rx/testing/hot_observable.rb
@@ -21,7 +21,7 @@ module Rx
 
       @messages.each do |message|
         notification = message.value
-        @scheduler.schedule_at_relative_with_state(nil, message.time, lambda {|scheduler1, state1|
+        @scheduler.schedule_relative_with_state(nil, message.time, lambda {|scheduler1, state1|
 
           @observers.clone.each {|observer| notification.accept observer }
 

--- a/lib/rx/testing/test_scheduler.rb
+++ b/lib/rx/testing/test_scheduler.rb
@@ -18,7 +18,7 @@ module Rx
     end
 
     # Schedules an action to be executed at due_time.
-    def schedule_at_absolute_with_state(state, due_time, action)
+    def schedule_absolute_with_state(state, due_time, action)
       raise 'action cannot be nil' unless action
 
       due_time = now + 1 if due_time <= now && @increment_on_simultaneous
@@ -43,24 +43,24 @@ module Rx
       subscription = nil
       observer = create_observer
 
-      schedule_at_absolute_with_state(nil, o[:created], lambda {|scheduler, state|
+      schedule_absolute_with_state(nil, o[:created], lambda {|scheduler, state|
         source = yield
         Subscription.empty
       })
 
-      schedule_at_absolute_with_state(nil, o[:subscribed], lambda {|scheduler, state|
+      schedule_absolute_with_state(nil, o[:subscribed], lambda {|scheduler, state|
         subscription = source.subscribe observer
         Subscription.empty
       })
 
-       schedule_at_absolute_with_state(nil, o[:disposed], lambda {|scheduler, state|
+       schedule_absolute_with_state(nil, o[:disposed], lambda {|scheduler, state|
         subscription.unsubscribe
         Subscription.empty
       })
 
       start
-      
-      observer           
+
+      observer
     end
 
     # Creates a hot observable using the specified timestamped notification messages.

--- a/lib/rx/testing/test_scheduler.rb
+++ b/lib/rx/testing/test_scheduler.rb
@@ -21,6 +21,7 @@ module Rx
     def schedule_absolute_with_state(state, due_time, action)
       raise 'action cannot be nil' unless action
 
+      due_time = due_time.ts if TestTime === due_time
       due_time = now + 1 if due_time <= now && @increment_on_simultaneous
 
       super(state, due_time, action)

--- a/lib/rx/testing/test_time.rb
+++ b/lib/rx/testing/test_time.rb
@@ -1,0 +1,36 @@
+module Rx
+  class TestTime < Time
+    include Comparable
+
+    attr_reader :ts
+
+    def initialize(ts)
+      super()
+      @ts = ts
+    end
+
+    def <=>(other)
+      if other.is_a? TestTime
+        @ts <=> other.ts
+      else
+        @ts <=> other
+      end
+    end
+
+    def +(other)
+      TestTime.new(other + @ts)
+    end
+
+    def -(other)
+      TestTime.new(other - @ts)
+    end
+
+    def to_s
+      "TestTime @ #{@ts.to_s}"
+    end
+
+    def inspect
+      "TestTime @ #{@ts.to_s}"
+    end
+  end
+end

--- a/test/rx/concurrency/helpers/historical_virtual_scheduler_helper.rb
+++ b/test/rx/concurrency/helpers/historical_virtual_scheduler_helper.rb
@@ -35,7 +35,7 @@ module HistoricalVirtualSchedulerTestHelper
   def test_relative_with_state
     state = []
     task  = ->(_, s) { s.push 1 }
-    @scheduler.schedule_at_relative_with_state(state, 2, task)
+    @scheduler.schedule_relative_with_state(state, 2, task)
     @scheduler.start
 
     assert_equal([1], state)
@@ -45,7 +45,7 @@ module HistoricalVirtualSchedulerTestHelper
   def test_relative
     ran  = false
     task = ->() { ran = true }
-    @scheduler.schedule_at_relative(2, task)
+    @scheduler.schedule_relative(2, task)
     @scheduler.start
 
     assert_equal(true, ran)
@@ -58,7 +58,7 @@ module HistoricalVirtualSchedulerTestHelper
     state = []
     time  = @start + 2
     task  = ->(_, s) { s.push 1 }
-    @scheduler.schedule_at_absolute_with_state(state, time, task)
+    @scheduler.schedule_absolute_with_state(state, time, task)
     @scheduler.start
 
     assert_equal([1], state)
@@ -69,7 +69,7 @@ module HistoricalVirtualSchedulerTestHelper
     ran   = false
     time  = @start + 2
     task  = ->() { ran = true }
-    @scheduler.schedule_at_absolute(time, task)
+    @scheduler.schedule_absolute(time, task)
     @scheduler.start
 
     assert_equal(true, ran)
@@ -83,8 +83,8 @@ module HistoricalVirtualSchedulerTestHelper
     task    = ->() { ran = true }
     failure = ->() { flunk "Should never reach." }
 
-    @scheduler.schedule_at_absolute(@start + 10, task)
-    @scheduler.schedule_at_absolute(@start + 11, failure)
+    @scheduler.schedule_absolute(@start + 10, task)
+    @scheduler.schedule_absolute(@start + 11, failure)
     @scheduler.advance_to(@start + 10)
 
     assert_equal(true, ran)
@@ -105,8 +105,8 @@ module HistoricalVirtualSchedulerTestHelper
     task    = ->() { ran = true }
     failure = ->() { flunk "Should never reach." }
 
-    @scheduler.schedule_at_relative(10, task)
-    @scheduler.schedule_at_relative(11, failure)
+    @scheduler.schedule_relative(10, task)
+    @scheduler.schedule_relative(11, failure)
     @scheduler.advance_by(10)
 
     assert_equal(true, ran)
@@ -119,7 +119,7 @@ module HistoricalVirtualSchedulerTestHelper
 
   def test_sleep
     failure = ->() { flunk "Should not run." }
-    @scheduler.schedule_at_relative(10, failure)
+    @scheduler.schedule_relative(10, failure)
     @scheduler.sleep(20)
 
     assert_equal(@start + 20, @scheduler.now)

--- a/test/rx/linq/observable/test_timer.rb
+++ b/test/rx/linq/observable/test_timer.rb
@@ -26,29 +26,20 @@ class TestOperatorTimer < Minitest::Test
 
     assert_msgs msgs('-----0--1--'), actual
   end
-end
-
-class TestOperatorAsyncTimer < Minitest::Test
-  include Rx::AsyncTesting
-  include Rx::ReactiveTest
-
-  def setup
-    @scheduler = Rx::TestScheduler.new
-    @observer = @scheduler.create_observer
-  end
 
   def test_emit_value_at_point_in_time
-    Rx::Observable.timer(Time.now).subscribe(@observer)
-    await_array_length(@observer.messages, 2)
-    expected = [on_next(0, 0), on_completed(0)]
-    assert_equal expected, @observer.messages
+    actual = scheduler.configure do
+      Rx::Observable.timer(Rx::TestTime.new(300), scheduler)
+    end
+
+    assert_msgs msgs('---(0|)'), actual
   end
 
-  def test_emit_value_at_repeated_point_in_time
-    Rx::Observable.timer(Time.now, 0.01).subscribe(@observer)
-    await_array_length(@observer.messages, 3)
-    events = @observer.messages.map {|m|  m.value }
-    assert events.all? {|v| Rx::OnNextNotification === v }
-    assert_equal [0, 1, 2], events.map {|v| v.value }.slice(0, 3)
+  def test_emit_periodic_values_after_point_in_time
+    actual = scheduler.configure do
+      Rx::Observable.timer(Rx::TestTime.new(500), 300, scheduler)
+    end
+
+    assert_msgs msgs('-----0--1--'), actual
   end
 end


### PR DESCRIPTION
There are several operators which take a `Time` argument and act at a point in time. This PR introduce the somewhat hacky `TestTime` which `===` `Time` and can therefore be used to signify an absolute point in "testing time". This means we can write marble-style virtual time tests for these operators and need not resort to async tests. For example:
```
actual = scheduler.configure do
  Rx::Observable.timer(Rx::TestTime.new(300), scheduler)
end
assert_msgs msgs('---(0|)'), actual 
```

This unearthed a bug where the `alias_method` directive (now removed) in `VirtualTimeScheduler` meant that invokation of `schedule_at_absolute_with_state` would bypass the `TestScheduler` and invoke `VirtualTimeScheduler`. Rather than try to correct this, the PR cleans up the naming of scheduler methods so as to make the alias unnecessary.