### PR TITLE
Ask simplecov to disregard platofrm specific and test raise operations

### DIFF
--- a/lib/rx/concurrency/threaded_enumerator.rb
+++ b/lib/rx/concurrency/threaded_enumerator.rb
@@ -10,11 +10,13 @@ module Rx
     ERROR = Object.new
     DONE = Object.new
 
+    # :nocov: #
     if RUBY_ENGINE == 'jruby'
       def self.new(*args, &block)
         Enumerator.new(*args, &block)
       end
     end
+    # :nocov: #
 
     # ThreadedEnumerator helper class
     class Yielder

--- a/lib/rx/testing/async_testing.rb
+++ b/lib/rx/testing/async_testing.rb
@@ -13,12 +13,16 @@ module Rx
 
     def await_array_length(array, expected, timeout = 2)
       return if await(timeout) { array.length == expected }
+      # :nocov: #
       flunk "Array expected to be #{expected} items but was #{array}"
+      # :nocov: #
     end
 
     def await_array_minimum_length(array, expected, timeout = 2)
       return if await(timeout) { array.length >= expected }
+      # :nocov: #
       flunk "Array expected to be at least #{expected} items but was #{array}"
+      # :nocov: #
     end
 
     def await_criteria(timeout, failure = nil, &block)
@@ -38,7 +42,9 @@ module Rx
         sleep Float(timeout) / 20
         return true if yield
       end
+      # :nocov: #
       return false
+      # :nocov: #
     end
   end
 end

--- a/lib/rx/testing/test_scheduler.rb
+++ b/lib/rx/testing/test_scheduler.rb
@@ -30,7 +30,9 @@ module Rx
     def configure(options = {})
       options.each {|key,_|
         unless [:created, :subscribed, :disposed].include? key
+          # :nocov: #
           raise ArgumentError, "Should be specified whether :created, :subscribed or :disposed, but the #{key.inspect}"
+          # :nocov: #
         end
       }
       o = {


### PR DESCRIPTION
The testing framework itself currently does not have tests. This means that some bits of it that are only used on failure will not be traversed in a successful run and thus not have coverage. Ignore those bits.