### PR TITLE
Various cleanups pending 0.1.0 release

### DIFF
--- a/lib/rx/concurrency/current_thread_scheduler.rb
+++ b/lib/rx/concurrency/current_thread_scheduler.rb
@@ -23,7 +23,7 @@ module Rx
     def schedule_relative_with_state(state, due_time, action)
       raise 'action cannot be nil' unless action
 
-      dt = self.now.to_i + Scheduler.normalize(due_time)
+      dt = now.to_i + Scheduler.normalize(due_time)
       si = ScheduledItem.new self, state, dt, &action
 
       local_queue = Thread.current[:queue]
@@ -35,7 +35,7 @@ module Rx
         Thread.current[:queue] = local_queue
 
         begin
-          self.class.run_trampoline local_queue
+          run_trampoline local_queue
         ensure
           Thread.current[:queue] = nil
         end
@@ -48,18 +48,14 @@ module Rx
 
     private
 
-    class << self
-      def run_trampoline(queue)
-        while item = queue.shift
-          unless item.cancelled?
-            wait = item.due_time - Scheduler.now.to_i
-            sleep wait if wait > 0
-            item.invoke unless item.cancelled?
-          end
+    def run_trampoline(queue)
+      while item = queue.shift
+        unless item.cancelled?
+          wait = item.due_time - now.to_i
+          sleep wait if wait > 0
+          item.invoke unless item.cancelled?
         end
       end
-
     end
-
   end
 end

--- a/lib/rx/testing/async_testing.rb
+++ b/lib/rx/testing/async_testing.rb
@@ -35,7 +35,7 @@ module Rx
     def await(timeout)
       deadline = Time.now + timeout
       while Time.now < deadline
-        sleep timeout / 20
+        sleep Float(timeout) / 20
         return true if yield
       end
       return false

--- a/lib/rx/testing/async_testing.rb
+++ b/lib/rx/testing/async_testing.rb
@@ -12,16 +12,27 @@ module Rx
     end
 
     def await_array_length(array, expected, timeout = 2)
-      return if await_criteria(timeout) { array.length == expected }
+      return if await(timeout) { array.length == expected }
       flunk "Array expected to be #{expected} items but was #{array}"
     end
 
     def await_array_minimum_length(array, expected, timeout = 2)
-      return if await_criteria(timeout) { array.length >= expected }
+      return if await(timeout) { array.length >= expected }
       flunk "Array expected to be at least #{expected} items but was #{array}"
     end
 
-    def await_criteria(timeout)
+    def await_criteria(timeout, failure = nil, &block)
+      unless await(timeout, &block)
+        # :nocov: #
+        failure ||= lambda { "Timed out after #{timeout} seconds" }
+        flunk failure.call
+        # :nocov: #
+      end
+    end
+
+    private
+
+    def await(timeout)
       deadline = Time.now + timeout
       while Time.now < deadline
         sleep timeout / 20

--- a/test/rx/concurrency/helpers/immediate_local_scheduler_helper.rb
+++ b/test/rx/concurrency/helpers/immediate_local_scheduler_helper.rb
@@ -38,14 +38,14 @@ module ImmediateLocalSchedulerTestHelper
     @scheduler.schedule_relative_with_state(state, 0, task)
 
     assert_equal([1], state)
-  end 
+  end
 
   def test_schedule_recursive_relative_with_state_simple
     state = []
     inner = ->(_, s) { s << 1 }
-    outer = ->(sched, s) { sched.schedule_relative_with_state(s, 1, inner) }
-    @scheduler.schedule_relative_with_state(state, 1, outer)
+    outer = ->(sched, s) { sched.schedule_relative_with_state(s, 0, inner) }
+    @scheduler.schedule_relative_with_state(state, 0, outer)
 
     assert_equal([1], state)
-  end 
+  end
 end

--- a/test/rx/concurrency/test_periodic_scheduler.rb
+++ b/test/rx/concurrency/test_periodic_scheduler.rb
@@ -20,9 +20,9 @@ class TestPeriodicScheduler < Minitest::Test
     task  = ->(x) { x << 1 }
 
     subscription = @scheduler.schedule_periodic_with_state(state, INTERVAL, task)
-    await_array_length(state, 2, INTERVAL * 2.9)
+    await_array_minimum_length(state, 2)
     subscription.unsubscribe
-    assert_equal(state.length, 2)
+    assert state.length >= 2
   end
 
   def test_periodic_with_state_exceptions
@@ -40,9 +40,9 @@ class TestPeriodicScheduler < Minitest::Test
     task  = ->() { state << 1 }
 
     subscription = @scheduler.schedule_periodic(INTERVAL, task)
-    await_array_length(state, 2, INTERVAL * 2.9)
+    await_array_minimum_length(state, 2)
     subscription.unsubscribe
-    assert_equal(state.length, 2)
+    assert state.length >= 2
   end
 
   def test_periodic_exceptions

--- a/test/rx/linq/observable/test_timer.rb
+++ b/test/rx/linq/observable/test_timer.rb
@@ -46,7 +46,7 @@ class TestOperatorAsyncTimer < Minitest::Test
 
   def test_emit_value_at_repeated_point_in_time
     Rx::Observable.timer(Time.now, 0.01).subscribe(@observer)
-    await_array_length(@observer.messages, 3)
+    await_array_minimum_length(@observer.messages, 3)
     events = @observer.messages.map {|m|  m.value }
     assert events.all? {|v| Rx::OnNextNotification === v }
     assert_equal [0, 1, 2], events.map {|v| v.value }.slice(0, 3)

--- a/test/rx/operators/test_repeat.rb
+++ b/test/rx/operators/test_repeat.rb
@@ -28,14 +28,7 @@ class TestCreationRepeat < Minitest::Test
 end
 
 class TestOperatorRepeat < Minitest::Test
-  include Rx::AsyncTesting
   include Rx::MarbleTesting
-
-  def setup
-    @scheduler = Rx::TestScheduler.new
-    @observer = @scheduler.create_observer
-    @err = RuntimeError.new
-  end
 
   def test_repeat
     source      = cold('  -12|')
@@ -66,30 +59,24 @@ class TestOperatorRepeat < Minitest::Test
       ).repeat(nil)
     end
   end
-  
+
   def test_repeat_infinitely
-    subscription = Rx::Observable.of(1, 2)
-      .repeat_infinitely
-      .subscribe_on(Rx::DefaultScheduler.instance)
-      .subscribe(@observer)
-    await_array_minimum_length(@observer.messages, 10)
-    subscription.unsubscribe
-    expected = ([
-      on_next(0, 1),
-      on_next(0, 2)
-    ] * 5).flatten
-    assert_messages expected, @observer.messages.take(10)
+    source      = cold('12|')
+    expected    = msgs('--12121212')
+    source_subs = subs('  ^ (!^) (!^) (!^) !')
+    actual = scheduler.configure { source.repeat_infinitely }
+    assert_msgs expected, actual
+    assert_subs source_subs, source
   end
-  
+
   def test_repeat_infinitely_breaks_on_error
-    res = @scheduler.configure do
-      @scheduler.create_cold_observable(
-        on_error(100, @err)
-      ).repeat_infinitely
-    end
-    expected = [
-      on_error(SUBSCRIBED + 100, @err)
-    ]
-    assert_messages expected, res.messages
+    source      = cold('  -12#')
+    expected    = msgs('---12#')
+    source_subs = subs('  ^  !')
+
+    actual = scheduler.configure { source.repeat_infinitely }
+
+    assert_msgs expected, actual
+    assert_subs source_subs, source
   end
 end

--- a/test/rx/operators/test_synchronization.rb
+++ b/test/rx/operators/test_synchronization.rb
@@ -28,20 +28,22 @@ class TestObservableSynchronization < Minitest::Test
     Rx::Observable.just(1).subscribe_on(Rx::CurrentThreadScheduler.instance).subscribe
   end
 
-  def test_subscribe_on_default_scheduler_with_merging
+  def test_subscribe_on_default_scheduler_with_merge_all
     observer = @scheduler.create_observer
-    Rx::Observable.of(Rx::Observable.from([1, 2]), Rx::Observable.from([3, 4]))
+    Rx::Observable.of(Rx::Observable.from([1, 2, 3]), Rx::Observable.from([4, 5, 6]))
       .subscribe_on(Rx::DefaultScheduler.instance)
       .merge_all
       .subscribe(observer)
 
-    await_array_length(observer.messages, 5)
+    await_array_length(observer.messages, 7, 4)
 
     expected = [
       on_next(0, 1),
       on_next(0, 2),
-      on_next(0, 3),
       on_next(0, 4),
+      on_next(0, 3),
+      on_next(0, 5),
+      on_next(0, 6),
       on_completed(0)
     ]
     assert_messages expected, observer.messages

--- a/test/rx/operators/test_to_h.rb
+++ b/test/rx/operators/test_to_h.rb
@@ -92,7 +92,7 @@ class TestOperatorToH < Minitest::Test
 
   def test_selector_configuration_fails_immediately
     source = cold('  -|')
-    assert_raises(RuntimeError) do
+    assert_raises(MyError) do
       source.to_h { |_| raise error }
     end
   end


### PR DESCRIPTION
Various async test and framework fixes.

Changelog entries:
- `CurrentThreadScheduler` is a singleton and now refers to instance members rather than class methods
- Properly synchronize `.delay` operator.
- reimplement `.merge_all` as `.merge_concurrent` with infinite concurrency
- local scheduler helper no longer delays test execution ~6 seconds; MRI now executes tests in less than 2 seconds
